### PR TITLE
V3 matrix optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm version](https://img.shields.io/npm/v/vectorious.svg?style=flat-square) ![npm downloads](https://img.shields.io/npm/dm/vectorious.svg?style=flat-square) ![travis](https://img.shields.io/travis/mateogianolio/vectorious.svg?style=flat-square)
 
-Vectorious is a generalized n-dimensional matrix and vector library written in JavaScript, which can be used both in node.js and the browser.
+Vectorious is a high performance linear algebra library written in Javascript, which can be used both in node.js and the browser.
 
 * [Installation](#installation-)
     * [For the browser](#for-the-browser-)

--- a/benchmarks/matrix.js
+++ b/benchmarks/matrix.js
@@ -2,16 +2,28 @@
   var Benchmark = require('benchmark'),
       vectorious = require('../vectorious'),
       suite = new Benchmark.Suite;
-  
+
   var Matrix = vectorious.Matrix;
-  
-  var a = Matrix.ones(128, 128),
-      b = Matrix.ones(128, 128).scale(2);
-  
-  log('a = Matrix.ones(128, 128)');
-  log('b = Matrix.ones(128, 128).scale(2)');
+
+  var N = 128;
+  var data = [];
+
+  for(var i = 0; i < N; i++){
+    var row = [];
+    for(var j = 0; j < N; j++){
+        row[j] = Math.random();
+    }
+    data.push(row);
+  }
+
+  var a = new Matrix(data),
+      b = new Matrix(data).scale(2);
+
+  log('data = randomArray(128, 128)')
+  log('a = Matrix(data)');
+  log('b = Matrix(data).scale(2)');
   log();
-  
+
   suite
     .add('Matrix.identity(128)', function() {
       Matrix.identity(128);

--- a/benchmarks/matrix.js
+++ b/benchmarks/matrix.js
@@ -5,16 +5,23 @@
 
   var Matrix = vectorious.Matrix;
 
-  var N = 128;
-  var data = [];
+  function randomArray(N, M){
 
-  for(var i = 0; i < N; i++){
-    var row = [];
-    for(var j = 0; j < N; j++){
-        row[j] = Math.random();
+    var data = [];
+
+    for(var i = 0; i < N; i++){
+      var row = [];
+      for(var j = 0; j < M; j++){
+          row[j] = Math.random();
+      }
+      data.push(row);
     }
-    data.push(row);
+
+    return data;
   }
+
+  var N = 128;
+  var data = randomArray(N, N);
 
   var a = new Matrix(data),
       b = new Matrix(data).scale(2);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,8 @@
 (function() {
   'use strict';
 
+  var package_json = require('./package');
+
   var browserify = require('browserify');
   var gulp = require('gulp');
   var source = require('vinyl-source-stream');
@@ -18,7 +20,7 @@
     });
 
     return b.bundle()
-      .pipe(source('vectorious-2.2.1.js'))
+      .pipe(source('vectorious-'+ package_json.version + '.js'))
       .pipe(buffer())
       .pipe(sourcemaps.init({loadMaps: true}))
           // Add transformation tasks to the pipeline here.

--- a/matrix.js
+++ b/matrix.js
@@ -7,7 +7,6 @@
     var self = this;
 
     self.shape = [];
-    self.transposed = false;
 
     if(data instanceof Float64Array && options.shape){
 
@@ -27,7 +26,6 @@
       self.shape = [data.shape[0], data.shape[1]];
       self.data = new Float64Array(data.data);
       self.type = Float64Array;
-      self.transposed = data.transposed;
 
       return self;
     }
@@ -39,7 +37,6 @@
     self.shape = shape;
     self.data = data;
     self.type = Float64Array;
-    self.transposed = false;
 
     return self;
   }
@@ -219,14 +216,19 @@
   // ?> transposes a matrix (mirror across the diagonal)
   // => returns a new resultant transposed matrix
   Matrix.prototype.transpose = function() {
-    var result = new Matrix(this);
-    // flag as transposed
-    result.transposed = !this.transposed;
-    // swap row and column counts
-    result.shape[0] = this.shape[1];
-    result.shape[1] = this.shape[0];
+    var r = this.shape[0],
+        c = this.shape[1];
 
-    return result;
+    var data = new Float64Array(c * r);
+
+    for(var i = 0; i < r; i++){
+      for(var j = 0; j < c; j++){
+        data[j * r + i] = this.data[i * c + j];
+      }
+    }
+
+    return Matrix.fromFloat64Array(data, [c, r]);
+
   };
 
   // Matrix.prototype.inverse
@@ -563,11 +565,8 @@
     if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
       throw new Error('index out of bounds');
 
-    if(!this.transposed){
-      return this.data[i*this.shape[1]+j];
-    } else {
-      return this.data[j*this.shape[1]+i];
-    }
+    return this.data[i*this.shape[1]+j];
+
   };
 
   // Matrix.prototype.set

--- a/matrix.js
+++ b/matrix.js
@@ -67,7 +67,7 @@
         d2 = matrix.data;
 
     if(r !== matrix.shape[0] || c !== matrix.shape[1])
-      throw new Error('sizes do not match');
+      throw new Error('sizes do not match: ' + r + 'x' + c + ', ' + matrix.shape[0] + 'x' + matrix.shape[1]);
 
     var data = new Float64Array(r * c);
 
@@ -77,7 +77,7 @@
       }
     }
 
-    return Matrix.fromFloat64Array(data, self.shape);
+    return Matrix.fromFloat64Array(data, this.shape);
   }
 
   // Matrix(.prototype).subtract
@@ -103,7 +103,7 @@
         }
       }
 
-      return Matrix.fromFloat64Array(data, self.shape);
+      return Matrix.fromFloat64Array(data, this.shape);
   };
 
   // Matrix.prototype.scale
@@ -122,7 +122,7 @@
       }
     }
 
-    return Matrix.fromFloat64Array(data, self.shape);
+    return Matrix.fromFloat64Array(data, this.shape);
   };
 
   // Matrix.zeros
@@ -150,7 +150,7 @@
 
 
     var data = new Float64Array(i * j);
-    data.fill(0.0);
+    data.fill(1.0);
 
     return Matrix.fromFloat64Array(data, [i, j]);
   };

--- a/matrix.js
+++ b/matrix.js
@@ -1,47 +1,57 @@
 (function() {
   'use strict';
-  
+
   var Vector = require('./vector.js');
-  
-  function Matrix() {
+
+  function Matrix(initial, options) {
     var self = this;
-    self.rows = [];
-    self.type = Float64Array;
-    
-    var args = [].slice.call(arguments),
-        argument,
-        i;
-    
-    for(i = 0; i < args.length; i++) {
-      if(typeof args[i] === 'function') {
-        self.type = args[i];
-        args.splice(i, 1);
-      }
-    }
-    
-    for(i = 0; i < args.length; i++) {
-      argument = args[i];
-      var j;
-      if(argument instanceof Matrix) {
-        self.augment(argument);
-      } else if(argument instanceof Vector) {
-        self.rows.push(argument);
-      } else if(typeof argument === 'number') {
-        for(j = 0; j < argument; j++)
-          self.rows.push(Vector.zeros(argument, self.type));
-      } else if(typeof argument === 'object') {
-        for(j = 0; j < argument.length; j++) {
-          if(argument[j] instanceof Vector)
-            self.rows.push(argument[j]);
-          else
-            self.rows.push(Vector.construct([argument[j], self.type]));
+
+    self.shape = [];
+
+    if(initial instanceof Float64Array && options.shape){
+
+        if(initial.length != options.shape[0] * options.shape[1]){
+            throw "Shape does not match typed array dimensions.";
         }
-      }
+        self.shape = options.shape;
+        self.data = initial;
+
+        return self;
+
+    } else if(Object.prototype.toString.call(initial) === '[object Array]'){
+        return Matrix.fromArray(initial);
     }
-    
-    return self;
   }
-  
+
+  Matrix.fromFloat64Array = function(data, shape){
+      var self = Object.create(Matrix.prototype);
+      self.shape = shape;
+      self.data = data;
+
+      return self;
+  }
+
+  Matrix.fromArray = function(array){
+      var shape = [],
+          data,
+          columns;
+
+      shape[0] = array.length;
+      shape[1] = array[0].length;
+      columns = shape[1];
+
+      data = new Float64Array(shape[0]*shape[1]);
+
+      for(var ii = 0; ii < shape[0]; ++ii){
+          for(var jj = 0; jj < shape[1]; ++jj){
+
+              data[ii*columns+jj] = array[ii][jj];
+          }
+      }
+
+      return Matrix.fromFloat64Array(data, shape);
+  }
+
   // Matrix(.prototype).add
   // ?> adds two matrices a and b together
   // => returns a new matrix containing the sum of a and b
@@ -55,10 +65,10 @@
         i, l;
     for(i = 0, l = a.length; i < l; i++)
       result.push(a[i].add(b[i]));
-    
+
     return Matrix.construct(result);
   };
-  
+
   // Matrix(.prototype).subtract
   // ?> subtracts the matrix b from matrix a
   // => returns a new matrix containing the difference between a and b
@@ -72,10 +82,10 @@
         i, l;
     for(i = 0, l = a.length; i < l; i++)
       result.push(a[i].subtract(b[i]));
-    
+
     return Matrix.construct(result);
   };
-  
+
   // Matrix.prototype.scale
   // ?> multiplies all elements of a matrix with a specified scalar
   // => returns a new resultant scaled matrix
@@ -85,10 +95,10 @@
         i, l;
     for(i = 0, l = rows.length; i < l; i++)
       result.push(rows[i].scale(scalar));
-    
+
     return Matrix.construct(result);
   };
-  
+
   // Matrix.zeros
   // ?> creates an i x j matrix containing zeros (0), takes an
   //    optional type argument which should be an instance of TypedArray
@@ -96,15 +106,15 @@
   Matrix.zeros = function(i, j, type) {
     if(i <= 0 || j <= 0)
       throw new Error('invalid size');
-    
+
     var result = [],
         row;
     for(row = 0; row < i; row++)
       result.push(Vector.zeros(j, type !== undefined ? type : Float64Array));
-    
+
     return Matrix.construct(result);
   };
-  
+
   // Matrix.ones
   // ?> creates an i x j matrix containing ones (1), takes an
   //    optional type argument which should be an instance of TypedArray
@@ -112,61 +122,66 @@
   Matrix.ones = function(i, j, type) {
     if(i <= 0 || j <= 0)
       throw new Error('invalid size');
-    
+
     var result = [],
         row;
     for(row = 0; row < i; row++)
       result.push(Vector.ones(j, type !== undefined ? type : Float64Array));
-    
+
     return Matrix.construct(result);
   };
-  
+
   // Matrix(.prototype).multiply
   // ?> multiplies two matrices a and b of matching dimensions together
   // => returns a new resultant matrix containing the matrix product of a and b
-  Matrix.multiply = function(a, b) {
-    return a.multiply(b);
+  Matrix.multiply = function(a, b, out) {
+    var r1 = a.shape[0],          // rows in this matrix
+      c1 = a.shape[1],          // columns in this matrix
+      r2 = b.shape[0],      // rows in multiplicand
+      c2 = b.shape[1],   // columns in multiplicand
+      d1 = a.data,
+      d2 = b.data;
+
+    if(c1 !== r2)
+        throw new Error('sizes do not match');
+
+    var data = out.data;
+
+    for(var ii = 0; ii < r1; ii++) {
+        for(var jj = 0; jj < c2; jj++) {
+          var sum = +0;
+
+          for(var kk = 0; kk < c1; kk++){
+            sum += d1[ii*c1+kk] * d2[jj+kk*c2];
+          }
+
+          data[ii*c2+jj] = sum;
+        }
+    }
   };
   Matrix.prototype.multiply = function(matrix) {
-    if(this.rows[0].length !== matrix.rows.length)
-      throw new Error('sizes do not match');
-    
-    var l = this.rows.length,
-        m = matrix.rows[0].length,
-        n = this.rows[0].length;
-    
-    var result = Matrix.zeros(l, m),
-        sum,
-        i, j, k;
-    for(i = 0; i < l; i++) {
-      for(j = 0; j < m; j++) {
-        sum = 0;
-        for(k = 0; k < n; k++)
-          sum += this.get(i, k) * matrix.get(k, j);
-        
-        result.set(i, j, sum);
-      }
-    }
-    
-    return result;
-  };
-  
+
+    var out = Matrix.fromFloat64Array(new Float64Array(this.shape[0] * matrix.shape[1]), [this.shape[0] ,matrix.shape[1]]);
+    Matrix.multiply(this, matrix, out);
+
+    return out;
+}
   // Matrix.prototype.transpose
   // ?> transposes a matrix (mirror across the diagonal)
   // => returns a new resultant transposed matrix
   Matrix.prototype.transpose = function() {
     var l = this.rows.length,
         m = this.rows[0].length;
-    
+
     var result = Matrix.zeros(m, l),
         i, j;
     for(i = 0; i < l; i++)
       for(j = 0; j < m; j++)
         result.set(j, i, this.get(i, j));
-    
+
     return result;
   };
-  
+
   // Matrix.prototype.inverse
   // ?> determines the inverse of any invertible square matrix using
   //    Gaussian elimination
@@ -174,14 +189,14 @@
   Matrix.prototype.inverse = function() {
     var l = this.rows.length,
         m = this.rows[0].length;
-    
+
     if(l !== m)
       throw new Error('invalid dimensions');
-    
+
     var identity = Matrix.identity(l);
     var augmented = Matrix.augment(this, identity);
     var gauss = augmented.gauss();
-    
+
     var left = Matrix.zeros(l, m),
         right = Matrix.zeros(l, m),
         n = gauss.rows[0].length,
@@ -194,68 +209,68 @@
           right.set(i, j - l, gauss.get(i, j));
       }
     }
-    
+
     if(!left.equals(Matrix.identity(l)))
       throw new Error('matrix is invertible');
-    
+
     return right;
   };
-  
+
   // Matrix.prototype.gauss
   // ?> performs Gaussian elimination on a matrix
   // => returns the matrix in reduced row echelon form
   Matrix.prototype.gauss = function() {
     var l = this.rows.length,
         m = this.rows[0].length;
-    
+
     var copy = new Matrix(this),
         lead = 0,
         pivot,
         i, j;
-    
+
     for(i = 0; i < l; i++) {
       if(m <= lead)
         return new Error('matrix is singular');
-      
+
       j = i;
       while(copy.get(j, lead) === 0) {
         j++;
         if(l === j) {
           j = i;
           lead++;
-          
+
           if(m === lead)
             return new Error('matrix is singular');
         }
       }
-      
+
       copy.swap(i, j);
-      
+
       pivot = copy.get(i, lead);
       if(pivot !== 0)
         copy.rows[i] = copy.rows[i].scale(1 / pivot);
-      
+
       for(j = 0; j < l; j++) {
         if(j !== i)
           copy.rows[j] = copy.rows[j].subtract(copy.rows[i].scale(copy.get(j, lead)));
       }
-      
+
       lead++;
     }
-    
+
     for(i = 0; i < l; i++) {
       pivot = 0;
       for(j = 0; j < m; j++)
         if(!pivot)
           pivot = copy.get(i, j);
-      
+
       if(pivot)
         copy.rows[i] = copy.rows[i].scale(1 / pivot);
     }
-    
+
     return copy;
   };
-  
+
   // Matrix.prototype.pivotize
   // ?> pivots a matrix until elements are in upper triangular form
   // => returns a tuple (array) of the resultant pivotized matrix and its sign
@@ -267,12 +282,12 @@
         pivot,
         lead,
         row;
-    
+
     var i, j;
     for(i = 0; i < l; i++) {
       pivot = 0;
       row = i;
-      
+
       for(j = i; j < l; j++) {
         lead = Math.abs(this.get(j, i));
         if(pivot < lead) {
@@ -280,49 +295,49 @@
           row = j;
         }
       }
-      
+
       if(i !== row) {
         result.swap(i, row);
         sign *= -1;
       }
     }
-    
+
     return [result, sign];
   };
-  
+
   // Matrix.prototype.lu
   // ?> performs LU factorization on a matrix
   // => returns a triple (array) of the lower triangular resultant matrix L, the upper
   //    triangular resultant matrix U and the pivot matrix P
   Matrix.prototype.lu = function() {
     var l = this.rows.length;
-    
+
     var L = Matrix.identity(l),
         U = Matrix.zeros(l, l),
         P = this.pivotize(),
         A = Matrix.multiply(P[0], this);
-    
+
     var i, j, k,
         sum = [0, 0];
-    
+
     for(i = 0; i < l; i++) {
       for(j = 0; j < i + 1; j++) {
         sum[0] = 0;
         for(k = 0; k < j; k++)
           sum[0] += U.get(k, i) * L.get(j, k);
-        
+
         U.set(j, i, A.get(j, i) - sum[0]);
       }
-      
+
       for(j = i; j < l; j++) {
         sum[1] = 0;
         for(k = 0; k < j; k++)
           sum[1] += U.get(k, i) * L.get(j, k);
-        
+
         L.set(j, i, (A.get(j, i) - sum[1]) / U.get(i, i));
       }
     }
-    
+
     return [L, U, P];
   };
 
@@ -338,13 +353,13 @@
     for(i = 0, l = matrix.rows.length; i < l; i++) {
       if(!(rows[i] instanceof Vector))
         rows[i] = new Vector();
-      
+
       rows[i].combine(matrix.rows[i]);
     }
-    
+
     return this;
   };
-  
+
   // Matrix.identity
   // ?> creates an identity matrix of size, takes an optional type argument
   //    which should be an instance of TypedArray
@@ -352,7 +367,7 @@
   Matrix.identity = function(size, type) {
     if(size < 0)
       throw new Error('invalid size');
-    
+
     type = type !== undefined ? type : Float64Array;
     var matrix = Matrix.zeros(size, size, type),
         i, j;
@@ -360,10 +375,10 @@
       for(j = 0; j < size; j++)
         if(i === j)
           matrix.set(i, j, 1);
-    
+
     return matrix;
   };
-  
+
   // Matrix.magic
   // ?> creates a magic square matrix of size, takes an optional type argument
   //    which should be an instance of TypedArray
@@ -371,11 +386,11 @@
   Matrix.magic = function(size, type) {
     if(size < 0)
       throw new Error('invalid size');
-    
+
     function f(n, x, y) {
       return (x + y * 2 + 1) % n;
     }
-    
+
     type = type !== undefined ? type : Float64Array;
     var magic = Matrix.zeros(size, size, type),
         i, j;
@@ -384,7 +399,7 @@
         magic.set(size - i - 1, size - j - 1, f(size, size - j - 1, i) * size + f(size, j, i) + 1);
       }
     }
-    
+
     return magic;
   };
 
@@ -394,35 +409,35 @@
   Matrix.prototype.diag = function() {
     var result = [],
         i, j, l, m;
-    
+
     for(i = 0, l = this.rows.length; i < l; i++)
       for(j = 0, m = this.rows[0].length; j < m; j++)
         if(i === j)
           result.push(this.get(i, j));
-    
+
     return Vector.construct(result);
   };
-  
+
   // Matrix.prototype.determinant
   // ?> gets the determinant of any square matrix using LU factorization
   // => returns the determinant of the matrix
   Matrix.prototype.determinant = function() {
     if(this.rows.length !== this.rows[0].length)
       throw new Error('matrix is not square');
-    
+
     var lu = this.lu();
     var P = lu.pop(),
         U = lu.pop(),
         L = lu.pop();
-    
+
     var sum = 0,
         product = 1,
         l = this.rows.length,
         i, j;
-    
+
     for(i = 0; i < l; i++)
       product *= L.get(i, i) * U.get(i, i);
-    
+
     return P.pop() * product;
   };
 
@@ -433,13 +448,13 @@
     var diagonal = this.diag(),
         result = 0,
         i, l;
-    
+
     for(i = 0, l = diagonal.length; i < l; i++)
       result += diagonal.get(i);
-    
+
     return result;
   };
-  
+
   // Matrix(.prototype).equals
   // ?> checks the equality of two matrices a and b
   // => returns true if equal, false otherwise
@@ -449,14 +464,14 @@
   Matrix.prototype.equals = function(matrix) {
     if(this.rows.length !== matrix.rows.length)
       return false;
-    
+
     var a = this.rows,
         b = matrix.rows,
         i, l;
     for(i = 0, l = a.length; i < l; i++)
       if(!a[i].equals(b[i]))
         return false;
-    
+
     return true;
   };
 
@@ -466,7 +481,7 @@
   Matrix.prototype.get = function(i, j) {
     return this.rows[i].get(j);
   };
-  
+
   // Matrix.prototype.set
   // ?> sets the element at row i, column j to value
   // => returns this for function chaining
@@ -474,21 +489,21 @@
     this.rows[i].set(j, value);
     return this;
   };
-  
+
   // Matrix.prototype.swap
   // ?> swaps two rows i and j in a matrix
   // => returns this for function chaining
   Matrix.prototype.swap = function(i, j) {
     if(i < 0 || j < 0 || i > this.rows.length - 1 || j > this.rows.length - 1)
       throw new Error('index out of bounds');
-    
+
     var copy = this.rows[i];
     this.rows[i] = this.rows[j];
     this.rows[j] = copy;
-    
+
     return this;
   };
-  
+
   // Matrix.prototype.map
   // ?> maps a function callback to all rows in a matrix
   // => returns the resultant mapped matrix
@@ -498,10 +513,10 @@
         i, l;
     for(i = 0, l = this.rows.length; i < l; i++)
       rows[i] = callback(rows[i]);
-    
+
     return result;
   };
-  
+
   // Matrix.prototype.each
   // ?> functional version of for-looping the rows in a matrix, is
   //    equivalent to Array.prototype.forEach
@@ -511,10 +526,10 @@
         i, l;
     for(i = 0, l = rows.length; i < l; i++)
       callback(rows[i], i);
-    
+
     return this;
   };
-  
+
   // Matrix.prototype.toString
   // ?> converts a matrix into a readable formatted string
   // => returns a string of the matrix' contents
@@ -524,10 +539,10 @@
         i, l;
     for(i = 0, l = rows.length; i < l; i++)
       result.push(rows[i].toString());
-    
+
     return '[' + result.join(', \n') + ']';
   };
-  
+
   // Matrix.prototype.toArray
   // ?> converts a matrix into a two-dimensional array
   // => returns an array of the matrix' contents
@@ -537,9 +552,9 @@
         i, l;
     for(i = 0, l = rows.length; i < l; i++)
       result.push(rows[i].toArray());
-    
+
     return result;
   };
-  
+
   module.exports = Matrix;
 })();

--- a/matrix.js
+++ b/matrix.js
@@ -551,12 +551,17 @@
   // ?> swaps two rows i and j in a matrix
   // => returns this for function chaining
   Matrix.prototype.swap = function(i, j) {
-    if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
+    if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[0] - 1)
       throw new Error('index out of bounds');
 
-    var copy = this.rows[i];
-    this.rows[i] = this.rows[j];
-    this.rows[j] = copy;
+    var c = this.shape[1];
+
+    // copy first row
+    var copy = this.data.slice(i * c, (i + 1) * c);
+    // move second row into first row spot
+    this.data.copyWithin(i * c, j * c, (j + 1) * c);
+    // copy first row back into second row spot
+    this.data.set(copy, j * c);
 
     return this;
   };
@@ -596,7 +601,8 @@
         c = this.shape[1];
 
     for(var i = 0; i < r; i++)
-      result.push('[' + this.data.subarray(i * c, i * c + r).toString() + ']');
+      // get string version of current row and store it
+      result.push('[' + this.data.subarray(i * c, (i + 1) * c ).toString() + ']');
 
     return '[' + result.join(', \n') + ']';
   };
@@ -610,7 +616,8 @@
         c = this.shape[1];
 
     for(var i = 0; i < r; i++)
-      result.push(Array.prototype.slice.call(this.data.subarray(i * c, i * c + r)));
+      // copy current row into a native array and store it
+      result.push(Array.prototype.slice.call(this.data.subarray(i * c, (i + 1) * c)));
 
     return result;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -15,6 +15,7 @@
         }
         self.shape = options.shape;
         self.data = initial;
+        self.type = Float64Array;
 
         return self;
 
@@ -27,6 +28,7 @@
       var self = Object.create(Matrix.prototype);
       self.shape = shape;
       self.data = data;
+      self.type = Float64Array;
 
       return self;
   }
@@ -34,19 +36,18 @@
   Matrix.fromArray = function(array){
       var shape = [],
           data,
-          columns;
+          c;   // number of columns
 
       shape[0] = array.length;
       shape[1] = array[0].length;
-      columns = shape[1];
+      c = shape[1];
 
       data = new Float64Array(shape[0]*shape[1]);
 
       for(var ii = 0; ii < shape[0]; ++ii){
-          for(var jj = 0; jj < shape[1]; ++jj){
-
-              data[ii*columns+jj] = array[ii][jj];
-          }
+        for(var jj = 0; jj < shape[1]; ++jj){
+          data[ii*c + jj] = array[ii][jj];
+        }
       }
 
       return Matrix.fromFloat64Array(data, shape);
@@ -58,16 +59,27 @@
   Matrix.add = function(a, b) {
     return a.add(b);
   };
-  Matrix.prototype.add = function(matrix) {
-    var result = [],
-        a = this.rows,
-        b = matrix.rows,
-        i, l;
-    for(i = 0, l = a.length; i < l; i++)
-      result.push(a[i].add(b[i]));
 
-    return Matrix.construct(result);
-  };
+  Matrix.prototype.add = function(matrix){
+      var r = this.shape[0],          // rows in this matrix
+          c = this.shape[1],          // columns in this matrix
+          d1 = this.data,
+          d2 = matrix.data;
+
+      if(r !== matrix.shape[0] || c !== matrix.shape[1])
+        throw new Error('sizes do not match');
+
+      var data = new Float64Array(r * c);
+
+      for(var ii = 0; ii < r; ii++) {
+        for(var jj = 0; jj < c; jj++) {
+          data[ii*c + jj] = d1[ii*c + jj] + d2[ii*c + jj]
+        }
+      }
+    };
+
+    return Matrix.fromFloat64Array(data, self.shape);
+  }
 
   // Matrix(.prototype).subtract
   // ?> subtracts the matrix b from matrix a
@@ -76,27 +88,42 @@
     return a.subtract(b);
   };
   Matrix.prototype.subtract = function(matrix) {
-    var result = [],
-        a = this.rows,
-        b = matrix.rows,
-        i, l;
-    for(i = 0, l = a.length; i < l; i++)
-      result.push(a[i].subtract(b[i]));
+      var r = this.shape[0],          // rows in this matrix
+          c = this.shape[1],          // columns in this matrix
+          d1 = this.data,
+          d2 = matrix.data;
 
-    return Matrix.construct(result);
+      if(r !== matrix.shape[0] || c !== matrix.shape[1])
+        throw new Error('sizes do not match');
+
+      var data = new Float64Array(r * c);
+
+      for(var ii = 0; ii < r; ii++) {
+        for(var jj = 0; jj < c; jj++) {
+          data[ii*c + jj] = d1[ii*c + jj] - d2[ii*c + jj]
+        }
+      }
+
+      return Matrix.fromFloat64Array(data, self.shape);
   };
 
   // Matrix.prototype.scale
   // ?> multiplies all elements of a matrix with a specified scalar
   // => returns a new resultant scaled matrix
   Matrix.prototype.scale = function(scalar) {
-    var result = [],
-        rows = this.rows,
-        i, l;
-    for(i = 0, l = rows.length; i < l; i++)
-      result.push(rows[i].scale(scalar));
+    var r = this.shape[0],          // rows in this matrix
+        c = this.shape[1],          // columns in this matrix
+        d1 = this.data;
 
-    return Matrix.construct(result);
+    var data = new Float64Array(r * c);
+
+    for(var ii = 0; ii < r; ii++) {
+      for(var jj = 0; jj < c; jj++) {
+        data[ii*c + jj] = d1[ii*c + jj] * scalar;
+      }
+    }
+
+    return Matrix.fromFloat64Array(data, self.shape);
   };
 
   // Matrix.zeros
@@ -107,12 +134,11 @@
     if(i <= 0 || j <= 0)
       throw new Error('invalid size');
 
-    var result = [],
-        row;
-    for(row = 0; row < i; row++)
-      result.push(Vector.zeros(j, type !== undefined ? type : Float64Array));
 
-    return Matrix.construct(result);
+    var data = new Float64Array(i * j);
+    data.fill(0.0);
+
+    return Matrix.fromFloat64Array(data, [i, j]);
   };
 
   // Matrix.ones
@@ -123,12 +149,11 @@
     if(i <= 0 || j <= 0)
       throw new Error('invalid size');
 
-    var result = [],
-        row;
-    for(row = 0; row < i; row++)
-      result.push(Vector.ones(j, type !== undefined ? type : Float64Array));
 
-    return Matrix.construct(result);
+    var data = new Float64Array(i * j);
+    data.fill(0.0);
+
+    return Matrix.fromFloat64Array(data, [i, j]);
   };
 
   // Matrix(.prototype).multiply

--- a/matrix.js
+++ b/matrix.js
@@ -481,7 +481,7 @@
   // ?> gets the determinant of any square matrix using LU factorization
   // => returns the determinant of the matrix
   Matrix.prototype.determinant = function() {
-    if(this.rows.length !== this.rows[0].length)
+    if(this.shape[0] !== this.shape[1])
       throw new Error('matrix is not square');
 
     var lu = this.lu();
@@ -491,7 +491,7 @@
 
     var sum = 0,
         product = 1,
-        l = this.rows.length,
+        l = this.shape[0],
         i, j;
 
     for(i = 0; i < l; i++)

--- a/matrix.js
+++ b/matrix.js
@@ -504,14 +504,14 @@
   // ?> gets the value of the element in row i, column j of a matrix
   // => returns the element at row i, column j of the matrix
   Matrix.prototype.get = function(i, j) {
-    return this.rows[i].get(j);
+    return this.data[i*this.shape[0]+j];
   };
 
   // Matrix.prototype.set
   // ?> sets the element at row i, column j to value
   // => returns this for function chaining
   Matrix.prototype.set = function(i, j, value) {
-    this.rows[i].set(j, value);
+    this.data[i*this.shape[0]+j] = value;
     return this;
   };
 

--- a/matrix.js
+++ b/matrix.js
@@ -461,7 +461,7 @@
         i, j;
     for(i = 0; i < size; i++) {
       for(j = 0; j < size; j++) {
-        magic.set(size - i - 1, size - j - 1, f(size, size - j - 1, i) * size + f(size, j, i) + 1);
+        magic.data[(size - i - 1) * size + (size - j - 1)] = f(size, size - j - 1, i) * size + f(size, j, i) + 1;
       }
     }
 

--- a/matrix.js
+++ b/matrix.js
@@ -391,6 +391,10 @@
     return new Matrix(a).augment(b);
   };
   Matrix.prototype.augment = function(matrix) {
+
+    if(matrix.shape.length === 0)
+     return this;
+
     var r1 = this.shape[0],
         c1 = this.shape[1],
         r2 = matrix.shape[0],

--- a/matrix.js
+++ b/matrix.js
@@ -403,9 +403,7 @@
     var matrix = Matrix.zeros(size, size, type),
         i, j;
     for(i = 0; i < size; i++)
-      for(j = 0; j < size; j++)
-        if(i === j)
-          matrix.set(i, j, 1);
+      matrix.data[i * size + i] = 1.0;
 
     return matrix;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -165,18 +165,23 @@
   // Matrix(.prototype).multiply
   // ?> multiplies two matrices a and b of matching dimensions together
   // => returns a new resultant matrix containing the matrix product of a and b
-  Matrix.multiply = function(a, b, out) {
-    var r1 = a.shape[0],          // rows in this matrix
-      c1 = a.shape[1],          // columns in this matrix
-      r2 = b.shape[0],      // rows in multiplicand
-      c2 = b.shape[1],   // columns in multiplicand
-      d1 = a.data,
-      d2 = b.data;
+  Matrix.multiply = function(a, b) {
+    return a.multiply(b);
+  };
+  Matrix.prototype.multiply = function(matrix) {
+
+    var r1 = this.shape[0],          // rows in this matrix
+      c1 = this.shape[1],          // columns in this matrix
+      r2 = matrix.shape[0],      // rows in multiplicand
+      c2 = matrix.shape[1],   // columns in multiplicand
+      d1 = matrix.data,
+      d2 = matrix.data;
 
     if(c1 !== r2)
         throw new Error('sizes do not match');
 
-    var data = out.data;
+    var out = Matrix.fromFloat64Array(new Float64Array(this.shape[0] * matrix.shape[1]), [this.shape[0] ,matrix.shape[1]]),
+        data = out.data;
 
     for(var ii = 0; ii < r1; ii++) {
         for(var jj = 0; jj < c2; jj++) {
@@ -189,11 +194,6 @@
           data[ii*c2+jj] = sum;
         }
     }
-  };
-  Matrix.prototype.multiply = function(matrix) {
-
-    var out = Matrix.fromFloat64Array(new Float64Array(this.shape[0] * matrix.shape[1]), [this.shape[0] ,matrix.shape[1]]);
-    Matrix.multiply(this, matrix, out);
 
     return out;
 }
@@ -531,7 +531,7 @@
   // ?> swaps two rows i and j in a matrix
   // => returns this for function chaining
   Matrix.prototype.swap = function(i, j) {
-    if(i < 0 || j < 0 || i > this.rows.length - 1 || j > this.rows.length - 1)
+    if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
       throw new Error('index out of bounds');
 
     var copy = this.rows[i];

--- a/matrix.js
+++ b/matrix.js
@@ -474,12 +474,12 @@
   Matrix.prototype.diag = function() {
     var r = this.shape[0],
         c = this.shape[1],
-        result = [];
+        data = new Float64Array(Math.min(r, c));
 
     for(var i = 0; i < r && i < c; i++)
-      result.push(this.data[i * c + i]);
+      data[i] = this.data[i * c + i];
 
-    return Vector.construct(result);
+    return new Vector(data);
   };
 
   // Matrix.prototype.determinant

--- a/matrix.js
+++ b/matrix.js
@@ -146,7 +146,14 @@
 
 
     var data = new Float64Array(i * j);
-    data.fill(0.0);
+    if(data.fill){
+      // fill not implmeneted on chrome version 43
+      data.fill(0.0);
+    } else {
+      for(var k = 0; k < i * j; k++){
+        data[k] = +0.0;
+      }
+    }
 
     return Matrix.fromFloat64Array(data, [i, j]);
   };
@@ -161,7 +168,14 @@
 
 
     var data = new Float64Array(i * j);
-    data.fill(1.0);
+    if(data.fill){
+      // fill not implmeneted on chrome version 43
+      data.fill(1.0);
+    } else {
+      for(var k = 0; k < i * j; k++){
+        data[k] = +1.0;
+      }
+    }
 
     return Matrix.fromFloat64Array(data, [i, j]);
   };

--- a/matrix.js
+++ b/matrix.js
@@ -436,13 +436,12 @@
   // ?> gets the diagonal of a matrix
   // => returns the diagonal of the matrix as a vector
   Matrix.prototype.diag = function() {
-    var result = [],
-        i, j, l, m;
+    var r = this.shape[0],
+        c = this.shape[1],
+        result = [];
 
-    for(i = 0, l = this.rows.length; i < l; i++)
-      for(j = 0, m = this.rows[0].length; j < m; j++)
-        if(i === j)
-          result.push(this.get(i, j));
+    for(var i = 0; i < r && i < c; i++)
+      result.push(this.data[i * c + i]);
 
     return Vector.construct(result);
   };

--- a/matrix.js
+++ b/matrix.js
@@ -218,8 +218,8 @@
   //    Gaussian elimination
   // => returns the inverse of the matrix
   Matrix.prototype.inverse = function() {
-    var l = this.rows.length,
-        m = this.rows[0].length;
+    var l = this.shape[0],
+        m = this.shape[1];
 
     if(l !== m)
       throw new Error('invalid dimensions');
@@ -490,15 +490,18 @@
     return a.equals(b);
   };
   Matrix.prototype.equals = function(matrix) {
-    if(this.rows.length !== matrix.rows.length)
+    var r = this.shape[0],
+        c = this.shape[1],
+        d1 = this.data,
+        d2 = this.data;
+
+    if(r !== matrix.shape[0] || c !== matrix.shape[1] || this.type != matrix.type)
       return false;
 
-    var a = this.rows,
-        b = matrix.rows,
-        i, l;
-    for(i = 0, l = a.length; i < l; i++)
-      if(!a[i].equals(b[i]))
+    for(var i = 0; i < r * c; i++){
+      if(d1[i] !== d2[i])
         return false;
+    }
 
     return true;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -510,6 +510,9 @@
   // ?> gets the value of the element in row i, column j of a matrix
   // => returns the element at row i, column j of the matrix
   Matrix.prototype.get = function(i, j) {
+    if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
+      throw new Error('index out of bounds');
+
     return this.data[i*this.shape[0]+j];
   };
 
@@ -517,6 +520,9 @@
   // ?> sets the element at row i, column j to value
   // => returns this for function chaining
   Matrix.prototype.set = function(i, j, value) {
+    if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
+      throw new Error('index out of bounds');
+
     this.data[i*this.shape[0]+j] = value;
     return this;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -175,7 +175,7 @@
       c1 = this.shape[1],          // columns in this matrix
       r2 = matrix.shape[0],      // rows in multiplicand
       c2 = matrix.shape[1],   // columns in multiplicand
-      d1 = matrix.data,
+      d1 = this.data,
       d2 = matrix.data;
 
     if(c1 !== r2)
@@ -319,7 +319,7 @@
   // => returns a tuple (array) of the resultant pivotized matrix and its sign
   //    (used in LU factorization)
   Matrix.prototype.pivotize = function() {
-    var l = this.rows.length,
+    var l = this.shape[0],
         result = Matrix.identity(l),
         sign = 1,
         pivot,
@@ -353,7 +353,7 @@
   // => returns a triple (array) of the lower triangular resultant matrix L, the upper
   //    triangular resultant matrix U and the pivot matrix P
   Matrix.prototype.lu = function() {
-    var l = this.rows.length;
+    var l = this.shape[0];
 
     var L = Matrix.identity(l),
         U = Matrix.zeros(l, l),

--- a/matrix.js
+++ b/matrix.js
@@ -549,7 +549,11 @@
     if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
       throw new Error('index out of bounds');
 
-    return this.data[i*this.shape[1]+j];
+    if(!this.transposed){
+      return this.data[i*this.shape[1]+j];
+    } else {
+      return this.data[j*this.shape[1]+i];
+    }
   };
 
   // Matrix.prototype.set

--- a/matrix.js
+++ b/matrix.js
@@ -593,10 +593,10 @@
   //    equivalent to Array.prototype.forEach
   // => returns this for function chaining
   Matrix.prototype.each = function(callback) {
-    var rows = this.rows,
-        i, l;
-    for(i = 0, l = rows.length; i < l; i++)
-      callback(rows[i], i);
+
+    var c = this.shape[1];
+
+    this.data.forEach(function(value, i){ callback(value, i / c | 0, i % c)});
 
     return this;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -29,6 +29,7 @@
 
       return self;
     }
+
   }
 
   Matrix.fromFloat64Array = function(data, shape){
@@ -379,14 +380,33 @@
     return new Matrix(a).augment(b);
   };
   Matrix.prototype.augment = function(matrix) {
-    var rows = this.rows,
-        i, l;
-    for(i = 0, l = matrix.rows.length; i < l; i++) {
-      if(!(rows[i] instanceof Vector))
-        rows[i] = new Vector();
+    var r1 = this.shape[0],
+        c1 = this.shape[1],
+        r2 = matrix.shape[0],
+        c2 = matrix.shape[1],
+        d1 = this.data,
+        d2 = matrix.data,
+        i, j;
 
-      rows[i].combine(matrix.rows[i]);
+    if(r1 !== r2)
+      throw new Error("Rows do not match.");
+
+    var data = new Float64Array((c1 + c2) * r1);
+
+    for(i = 0; i < r1; i++){
+      for(j = 0; j < c1; j++){
+        data[i * (c1 + c2) + j] = d1[i * r1 + j];
+      }
     }
+
+    for(i = 0; i < r1; i++){
+      for(j = 0; j < c2; j++){
+        data[i * (c1 + c2) + j + c1] = d2[i * r1 + j];
+      }
+    }
+
+    this.shape = [r1, c1 + c2];
+    this.data = data;
 
     return this;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -25,32 +25,32 @@
   }
 
   Matrix.fromFloat64Array = function(data, shape){
-      var self = Object.create(Matrix.prototype);
-      self.shape = shape;
-      self.data = data;
-      self.type = Float64Array;
+    var self = Object.create(Matrix.prototype);
+    self.shape = shape;
+    self.data = data;
+    self.type = Float64Array;
 
-      return self;
+    return self;
   }
 
   Matrix.fromArray = function(array){
-      var shape = [],
-          data,
-          c;   // number of columns
+    var shape = [],
+        data,
+        c;   // number of columns
 
-      shape[0] = array.length;
-      shape[1] = array[0].length;
-      c = shape[1];
+    shape[0] = array.length;
+    shape[1] = array[0].length;
+    c = shape[1];
 
-      data = new Float64Array(shape[0]*shape[1]);
+    data = new Float64Array(shape[0]*shape[1]);
 
-      for(var ii = 0; ii < shape[0]; ++ii){
-        for(var jj = 0; jj < shape[1]; ++jj){
-          data[ii*c + jj] = array[ii][jj];
-        }
+    for(var ii = 0; ii < shape[0]; ++ii){
+      for(var jj = 0; jj < shape[1]; ++jj){
+        data[ii*c + jj] = array[ii][jj];
       }
+    }
 
-      return Matrix.fromFloat64Array(data, shape);
+    return Matrix.fromFloat64Array(data, shape);
   }
 
   // Matrix(.prototype).add
@@ -61,22 +61,21 @@
   };
 
   Matrix.prototype.add = function(matrix){
-      var r = this.shape[0],          // rows in this matrix
-          c = this.shape[1],          // columns in this matrix
-          d1 = this.data,
-          d2 = matrix.data;
+    var r = this.shape[0],          // rows in this matrix
+        c = this.shape[1],          // columns in this matrix
+        d1 = this.data,
+        d2 = matrix.data;
 
-      if(r !== matrix.shape[0] || c !== matrix.shape[1])
-        throw new Error('sizes do not match');
+    if(r !== matrix.shape[0] || c !== matrix.shape[1])
+      throw new Error('sizes do not match');
 
-      var data = new Float64Array(r * c);
+    var data = new Float64Array(r * c);
 
-      for(var ii = 0; ii < r; ii++) {
-        for(var jj = 0; jj < c; jj++) {
-          data[ii*c + jj] = d1[ii*c + jj] + d2[ii*c + jj]
-        }
+    for(var ii = 0; ii < r; ii++) {
+      for(var jj = 0; jj < c; jj++) {
+        data[ii*c + jj] = d1[ii*c + jj] + d2[ii*c + jj]
       }
-    };
+    }
 
     return Matrix.fromFloat64Array(data, self.shape);
   }

--- a/matrix.js
+++ b/matrix.js
@@ -267,7 +267,7 @@
         return new Error('matrix is singular');
 
       j = i;
-      while(copy.get(j, lead) === 0) {
+      while(copy.data[j * m + lead] === 0) {
         j++;
         if(l === j) {
           j = i;
@@ -280,7 +280,7 @@
 
       copy.swap(i, j);
 
-      pivot = copy.get(i, lead);
+      pivot = copy.data[i * m + lead];
       if(pivot !== 0){
         // scale down the row by value of pivot
         for(k = 0; k < m; k++)
@@ -304,7 +304,7 @@
       pivot = 0;
       for(j = 0; j < m; j++)
         if(!pivot)
-          pivot = copy.get(i, j);
+          pivot = copy.data[i * m + j];
 
       if(pivot)
         // scale down the row by value of pivot

--- a/matrix.js
+++ b/matrix.js
@@ -231,7 +231,7 @@
 
     var left = Matrix.zeros(l, m),
         right = Matrix.zeros(l, m),
-        n = gauss.rows[0].length,
+        n = gauss.shape[1],
         i, j;
     for(i = 0; i < l; i++) {
       for(j = 0; j < n; j++) {
@@ -243,7 +243,7 @@
     }
 
     if(!left.equals(Matrix.identity(l)))
-      throw new Error('matrix is invertible');
+      throw new Error('matrix is not invertible');
 
     return right;
   };
@@ -524,7 +524,7 @@
     var r = this.shape[0],
         c = this.shape[1],
         d1 = this.data,
-        d2 = this.data;
+        d2 = matrix.data;
 
     if(r !== matrix.shape[0] || c !== matrix.shape[1] || this.type != matrix.type)
       return false;
@@ -581,11 +581,9 @@
   // ?> maps a function callback to all rows in a matrix
   // => returns the resultant mapped matrix
   Matrix.prototype.map = function(callback) {
-    var result = new Matrix(this),
-        rows = result.rows,
-        i, l;
-    for(i = 0, l = this.rows.length; i < l; i++)
-      rows[i] = callback(rows[i]);
+    var result = new Matrix(this);
+
+    result.data = this.data.map(callback);
 
     return result;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -21,6 +21,13 @@
 
     } else if(Object.prototype.toString.call(initial) === '[object Array]'){
         return Matrix.fromArray(initial);
+    } else if(initial instanceof Matrix){
+      // copy contructor
+      self.shape = [initial.shape[0], initial.shape[1]];
+      self.data = new Float64Array(initial.data);
+      self.type = Float64Array;
+
+      return self;
     }
   }
 

--- a/matrix.js
+++ b/matrix.js
@@ -252,13 +252,14 @@
   // ?> performs Gaussian elimination on a matrix
   // => returns the matrix in reduced row echelon form
   Matrix.prototype.gauss = function() {
-    var l = this.rows.length,
-        m = this.rows[0].length;
+    var l = this.shape[0],
+        m = this.shape[1];
 
     var copy = new Matrix(this),
         lead = 0,
         pivot,
-        i, j;
+        i, j, k,
+        leadValue;
 
     for(i = 0; i < l; i++) {
       if(m <= lead)
@@ -279,12 +280,20 @@
       copy.swap(i, j);
 
       pivot = copy.get(i, lead);
-      if(pivot !== 0)
-        copy.rows[i] = copy.rows[i].scale(1 / pivot);
+      if(pivot !== 0){
+        // scale down the row by value of pivot
+        for(k = 0; k < m; k++)
+          copy.data[(i * m) + k] = copy.data[(i * m) + k] / pivot;
+
+      }
+
 
       for(j = 0; j < l; j++) {
+        leadValue = copy.data[j * m + lead];
         if(j !== i)
-          copy.rows[j] = copy.rows[j].subtract(copy.rows[i].scale(copy.get(j, lead)));
+          for(k = 0; k < m; k++)
+            copy.data[j * m + k] = copy.data[j * m + k] - (copy.data[i * m + k] * leadValue);
+
       }
 
       lead++;
@@ -297,7 +306,9 @@
           pivot = copy.get(i, j);
 
       if(pivot)
-        copy.rows[i] = copy.rows[i].scale(1 / pivot);
+        // scale down the row by value of pivot
+        for(k = 0; k < m; k++)
+          copy.data[(i * m) + k] = copy.data[(i * m) + k] / pivot;
     }
 
     return copy;
@@ -533,7 +544,7 @@
     if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
       throw new Error('index out of bounds');
 
-    return this.data[i*this.shape[0]+j];
+    return this.data[i*this.shape[1]+j];
   };
 
   // Matrix.prototype.set
@@ -543,7 +554,7 @@
     if(i < 0 || j < 0 || i > this.shape[0] - 1 || j > this.shape[1] - 1)
       throw new Error('index out of bounds');
 
-    this.data[i*this.shape[0]+j] = value;
+    this.data[i*this.shape[1]+j] = value;
     return this;
   };
 

--- a/matrix.js
+++ b/matrix.js
@@ -7,6 +7,7 @@
     var self = this;
 
     self.shape = [];
+    self.transposed = false;
 
     if(data instanceof Float64Array && options.shape){
 
@@ -26,6 +27,7 @@
       self.shape = [data.shape[0], data.shape[1]];
       self.data = new Float64Array(data.data);
       self.type = Float64Array;
+      self.transposed = data.transposed;
 
       return self;
     }
@@ -37,6 +39,7 @@
     self.shape = shape;
     self.data = data;
     self.type = Float64Array;
+    self.transposed = false;
 
     return self;
   }
@@ -202,14 +205,12 @@
   // ?> transposes a matrix (mirror across the diagonal)
   // => returns a new resultant transposed matrix
   Matrix.prototype.transpose = function() {
-    var l = this.rows.length,
-        m = this.rows[0].length;
-
-    var result = Matrix.zeros(m, l),
-        i, j;
-    for(i = 0; i < l; i++)
-      for(j = 0; j < m; j++)
-        result.set(j, i, this.get(i, j));
+    var result = new Matrix(this);
+    // flag as transposed
+    result.transposed = !this.transposed;
+    // swap row and column counts
+    result.shape[0] = this.shape[1];
+    result.shape[1] = this.shape[0];
 
     return result;
   };

--- a/matrix.js
+++ b/matrix.js
@@ -3,28 +3,28 @@
 
   var Vector = require('./vector.js');
 
-  function Matrix(initial, options) {
+  function Matrix(data, options) {
     var self = this;
 
     self.shape = [];
 
-    if(initial instanceof Float64Array && options.shape){
+    if(data instanceof Float64Array && options.shape){
 
-        if(initial.length != options.shape[0] * options.shape[1]){
+        if(data.length != options.shape[0] * options.shape[1]){
             throw "Shape does not match typed array dimensions.";
         }
         self.shape = options.shape;
-        self.data = initial;
+        self.data = data;
         self.type = Float64Array;
 
         return self;
 
-    } else if(Object.prototype.toString.call(initial) === '[object Array]'){
-        return Matrix.fromArray(initial);
-    } else if(initial instanceof Matrix){
+    } else if(Object.prototype.toString.call(data) === '[object Array]'){
+        return Matrix.fromArray(data);
+    } else if(data instanceof Matrix){
       // copy contructor
-      self.shape = [initial.shape[0], initial.shape[1]];
-      self.data = new Float64Array(initial.data);
+      self.shape = [data.shape[0], data.shape[1]];
+      self.data = new Float64Array(data.data);
       self.type = Float64Array;
 
       return self;
@@ -592,10 +592,11 @@
   // => returns a string of the matrix' contents
   Matrix.prototype.toString = function() {
     var result = [],
-        rows = this.rows,
-        i, l;
-    for(i = 0, l = rows.length; i < l; i++)
-      result.push(rows[i].toString());
+        r = this.shape[0],
+        c = this.shape[1];
+
+    for(var i = 0; i < r; i++)
+      result.push('[' + this.data.subarray(i * c, i * c + r).toString() + ']');
 
     return '[' + result.join(', \n') + ']';
   };
@@ -605,10 +606,11 @@
   // => returns an array of the matrix' contents
   Matrix.prototype.toArray = function() {
     var result = [],
-        rows = this.rows,
-        i, l;
-    for(i = 0, l = rows.length; i < l; i++)
-      result.push(rows[i].toArray());
+        r = this.shape[0],
+        c = this.shape[1];
+
+    for(var i = 0; i < r; i++)
+      result.push(Array.prototype.slice.call(this.data.subarray(i * c, i * c + r)));
 
     return result;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectorious",
-  "version": "2.2.4",
+  "version": "3.0.0",
   "description": "A generalized n-dimensional matrix and vector library in JavaScript.",
   "main": "vectorious.js",
   "scripts": {

--- a/test/matrix.js
+++ b/test/matrix.js
@@ -1,12 +1,12 @@
 (function() {
   'use strict';
-  
+
   var vectorious = require('../vectorious'),
       assert = require('assert');
-  
+
   var Matrix = vectorious.Matrix;
   var Vector = vectorious.Vector;
-  
+
   describe('Matrix', function() {
     describe('Matrix.add(a, b)', function() {
       it('should work as the static equivalent of a.add(b)', function() {
@@ -16,7 +16,7 @@
         assert.deepEqual(new Matrix(a).add(b), Matrix.add(a, b));
       });
     });
-    
+
     describe('Matrix.subtract(a, b)', function() {
       it('should work as the static equivalent of a.subtract(b)', function() {
         var a = new Matrix([[1, 1, 1]]);
@@ -25,7 +25,7 @@
         assert.deepEqual(new Matrix(a).subtract(b), Matrix.subtract(a, b));
       });
     });
-    
+
     describe('Matrix.multiply(a, b)', function() {
       it('should work as the static equivalent of a.multiply(b)', function() {
         var a = new Matrix([[1, 1, 1]]);
@@ -34,7 +34,7 @@
         assert.deepEqual(new Matrix(a).multiply(b), Matrix.multiply(a, b));
       });
     });
-    
+
     describe('Matrix.augment(a, b)', function() {
       it('should work as the static equivalent of a.augment(b)', function() {
         var a = new Matrix([[1, 1, 1]]);
@@ -43,7 +43,7 @@
         assert.deepEqual(new Matrix(a).augment(b), Matrix.augment(a, b));
       });
     });
-    
+
     describe('Matrix.equals(a, b)', function() {
       it('should work as the static equivalent of a.equals(b)', function() {
         var a = new Matrix([[1, 1, 1]]);
@@ -52,7 +52,7 @@
         assert.deepEqual(new Matrix(a).equals(b), Matrix.equals(a, b));
       });
     });
-    
+
     describe('Matrix.identity()', function() {
       it('should throw error if invalid size', function() {
         assert.throws(Matrix.identity.bind(new Matrix(), -1), Error);
@@ -63,7 +63,7 @@
         assert.deepEqual(new Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), Matrix.identity(3));
       });
     });
-    
+
     describe('Matrix.magic()', function() {
       it('should throw error if invalid size', function() {
         assert.throws(Matrix.magic.bind(new Matrix(), -1), Error);
@@ -161,40 +161,54 @@
           var c = new Matrix([[5]]);
           var d = new Matrix([[1, 2], [2, 4]]);
 
+          var e = new Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+          var f = new Matrix([[ 30,  36,  42], [ 66,  81,  96], [102, 126, 150]]);
+
+          var g = new Matrix([[0,1,0], [1,0,0], [0,0,1]]);
+          var h = new Matrix([[1,3,5], [2,4,7], [1,1,0]]);
+          var i = new Matrix([[2, 4, 7], [1, 3, 5], [1, 1, 0]]);
+
           assert.deepEqual(c, a.multiply(b));
           assert.deepEqual(d, b.multiply(a));
+          assert.deepEqual(f, e.multiply(e));
+          assert.deepEqual(i, g.multiply(h))
         });
       });
 
       describe('.transpose()', function() {
-        it('should work as expected', function() {
-          var a = new Matrix([[1, 2]]);
-          var b = new Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
-          var c = new Matrix([[1], [2]]);
-          var d = new Matrix([[1, 4, 7], [2, 5, 8], [3, 6, 9]]);
+        var a = new Matrix([[1, 2]]);
+        var b = new Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+        var c = new Matrix([[1], [2]]);
+        var d = new Matrix([[1, 4, 7], [2, 5, 8], [3, 6, 9]]);
 
-          assert.deepEqual(c, a.transpose());
-          assert.deepEqual(d, b.transpose());
+        it('should compose properly with accessors', function() {
+
+          for(var i = 0; i < c.shape[0]; i++){
+            for(var j = 0; j < c.shape[1]; j++){
+              assert.equal(c.get(i, j), a.transpose().get(i, j));
+              assert.equal(d.get(i, j), b.transpose().get(i, j));
+            }
+          }
         });
       });
-      
+
       describe('.inverse()', function() {
         it('should throw error if matrix is not square', function() {
           var a = new Matrix([[1, 2]]);
-          
+
           assert.throws(a.inverse.bind(a), Error);
         });
-        
-        it('should throw error if matrix is invertible', function() {
+
+        it('should throw error if matrix is not invertible', function() {
           var a = new Matrix([
             [1, 2, 3],
             [4, 5, 6],
             [7, 8, 9]
           ]);
-          
+
           assert.throws(a.inverse.bind(a), Error);
         });
-        
+
         it('should work as expected', function() {
           var a = new Matrix([
             [2, -1, 0],
@@ -206,12 +220,10 @@
             [1/2, 1, 1/2],
             [1/4, 1/2, 3/4]
           ]);
-          
+
           // need to round result to avoid floating point rounding errors, e.g. 0.99999999994
-          assert.deepEqual(b, a.inverse().map(function(row) {
-            return row.map(function(value) {
-              return Number(value.toFixed(2));
-            });
+          assert.deepEqual(b, a.inverse().map(function(value) {
+            return Number(value.toFixed(2));
           }));
         });
       });
@@ -229,21 +241,21 @@
           assert.deepEqual(d, c.gauss());
         });
       });
-      
+
       describe('.pivotize()', function() {
         it('should work as expected', function() {
           var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
           var b = new Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 1]]);
-          
+
           assert.deepEqual(b, a.pivotize().shift());
-          
+
           var c = new Matrix([[11, 9, 24, 2], [1, 5, 2, 6], [3, 17, 18, 1], [2, 5, 7, 1]]);
           var d = new Matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]);
-          
+
           assert.deepEqual(d, c.pivotize().shift());
         });
       });
-      
+
       describe('.lu()', function() {
         it('should work as expected', function() {
           var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
@@ -251,20 +263,18 @@
             new Matrix([[1, 0, 0], [0.5, 1, 0], [0.5, -1, 1]]),
             new Matrix([[2, 4, 7], [0, 1, 1.5], [0, 0, -2]]),
           ];
-          
+
           assert.deepEqual(b, a.lu().splice(0, 2));
-          
+
           var c = new Matrix([[11, 9, 24, 2], [1, 5, 2, 6], [3, 17, 18, 1], [2, 5, 7, 1]]);
           var d = [
             new Matrix([[1, 0, 0, 0], [0.27273, 1, 0, 0], [0.09091, 0.2875, 1, 0], [0.18182, 0.23125, 0.0036, 1]]),
             new Matrix([[11, 9, 24, 2], [0, 14.54545, 11.45455, 0.45455], [0, 0, -3.475, 5.6875], [0, 0, 0, 0.51079]]),
           ];
-          
+
           assert.deepEqual(d, c.lu().splice(0, 2).map(function(matrix) {
-            return matrix.map(function(row) {
-              return row.map(function(value) {
-                return Number(value.toFixed(5));
-              });
+            return matrix.map(function(value) {
+              return Number(value.toFixed(5));
             });
           }));
         });
@@ -305,13 +315,13 @@
           assert.equal(5, b.trace());
         });
       });
-      
+
       describe('.determinant()', function() {
         it('should throw error if matrix is not square', function() {
           var a = new Matrix([[0, 0]]);
           assert.throws(a.determinant.bind(a), Error);
         });
-        
+
         it('should work as expected', function() {
           var a = new Matrix([[1, 2], [3, 4]]);
           var b = new Matrix([[1, 5, 6], [3.3, 9, 10], [7, 9, 3.2]]);
@@ -325,11 +335,12 @@
 
       describe('.equals()', function() {
         it('should work as expected', function() {
-          var a = new Matrix([[1, 2], [3, 4]]);
+          var a = new Matrix([[1, 2], [3, 4]]),
+              b = new Matrix([3, 4], [1, 2]);
 
           assert.equal(true, a.equals(new Matrix([[1, 2], [3, 4]])));
           assert.equal(true, new Matrix().equals(new Matrix()));
-          assert.equal(false, a.equals(a.transpose()));
+          assert.equal(false, a.equals(b));
         });
       });
 
@@ -344,12 +355,13 @@
         });
 
         it('should work as expected', function() {
-          var a = new Matrix([[1, 2], [3, 4]]);
+          var a = new Matrix([[1, 2], [3, 4], [5, 6]]);
 
           assert.equal(1, a.get(0, 0));
           assert.equal(2, a.get(0, 1));
           assert.equal(3, a.get(1, 0));
           assert.equal(4, a.get(1, 1));
+          assert.equal(5, a.get(2, 0));
         });
       });
 
@@ -400,7 +412,7 @@
       describe('.map()', function() {
         it('should work as expected', function() {
           var a = new Matrix([[1, 2, 3], [4, 5, 6]]);
-          var b = a.map(function(vector) { return vector.scale(2); });
+          var b = a.map(function(element) { return element * 2; });
 
           assert.deepEqual(new Matrix([[2, 4, 6], [8, 10, 12]]), b);
         });
@@ -411,10 +423,8 @@
           var a = new Matrix([[1, 2], [3, 4]]);
           var b = Matrix.zeros(2, 2);
 
-          a.each(function(vector, i) {
-            vector.each(function(value, j) {
-              b.set(i, j, value * j);
-            });
+          a.each(function(value, i, j){
+            b.set(i, j, value * j);
           });
 
           assert.deepEqual(new Matrix([[0, 2], [0, 4]]), b);
@@ -423,13 +433,15 @@
 
       describe('.toString()', function() {
         it('should work as expected', function() {
-          assert.equal('[[1, 2], \n[3, 4]]', new Matrix([[1, 2], [3, 4]]).toString());
+          assert.equal('[[1,2], \n[3,4]]', new Matrix([[1, 2], [3, 4]]).toString());
+            assert.equal('[[1,2], \n[3,4], \n[5,6]]', new Matrix([[1, 2], [3, 4], [5, 6]]).toString());
         });
       });
 
       describe('.toArray()', function() {
         it('should work as expected', function() {
           assert.deepEqual([[1, 2], [3, 4]], new Matrix([[1, 2], [3, 4]]).toArray());
+          assert.deepEqual([[1, 2], [3, 4], [5, 6]], new Matrix([[1, 2], [3, 4], [5, 6]]).toArray());
         });
       });
     });

--- a/test/matrix.js
+++ b/test/matrix.js
@@ -7,6 +7,21 @@
   var Matrix = vectorious.Matrix;
   var Vector = vectorious.Vector;
 
+  function randomArray(N, M){
+
+    var data = [];
+
+    for(var i = 0; i < N; i++){
+      var row = [];
+      for(var j = 0; j < M; j++){
+          row[j] = Math.random();
+      }
+      data.push(row);
+    }
+
+    return data;
+  }
+
   describe('Matrix', function() {
     describe('Matrix.add(a, b)', function() {
       it('should work as the static equivalent of a.add(b)', function() {
@@ -180,15 +195,18 @@
         var b = new Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
         var c = new Matrix([[1], [2]]);
         var d = new Matrix([[1, 4, 7], [2, 5, 8], [3, 6, 9]]);
+        var e = new Matrix(randomArray(20, 20));
 
-        it('should compose properly with accessors', function() {
+        it('should work as expected', function() {
 
-          for(var i = 0; i < c.shape[0]; i++){
-            for(var j = 0; j < c.shape[1]; j++){
-              assert.equal(c.get(i, j), a.transpose().get(i, j));
-              assert.equal(d.get(i, j), b.transpose().get(i, j));
-            }
-          }
+          assert.deepEqual(a, c.transpose());
+          assert.deepEqual(c, a.transpose());
+
+          assert.deepEqual(b, d.transpose());
+          assert.deepEqual(d, b.transpose());
+
+          assert.deepEqual(e, e.transpose().transpose());
+
         });
       });
 


### PR DESCRIPTION
Still a lot to do here, but I wanted to open the PR in case you guys were curious.

Purpose of these changes is to optimize matrix multiplies (and other operations) by moving to a single TypedArray, instead of the row vector format. These changes speed matrix multiply up by 10x for me, and likely give significant speed improvements for some other operations.

Some changes require node >= 4.0 (specifically the `ones` and `zeros` methods).