### PR TITLE
LAPACK C++ bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "4.0"
 before_install:
-  - sudo apt-get install libblas-dev
+  - sudo apt-get install libblas-dev liblapack-dev
 env:
   - CXX=g++-4.8
 addons:

--- a/benchmarks/matrix.js
+++ b/benchmarks/matrix.js
@@ -7,9 +7,11 @@
 
   var N = 128,
       a = Matrix.random(N, N),
-      b = Matrix.random(N, N);
+      b = Matrix.random(N, N),
+      rhs = Matrix.random(N, 1);
 
   console.log('a, b = Matrix.random(' + N + ', ' + N + ')');
+  console.log('rhs = Matrix.random(' + N + ', 1)');
 
   suite
     .add('Matrix.identity(' + N + ')', function () { Matrix.identity(N); })
@@ -30,6 +32,7 @@
     .add('a.gauss()', function () { a.gauss(); })
     .add('a.lu()', function () { a.lu(); })
     .add('a.plu()', function () { a.plu(); })
+    .add('a.solve(rhs)', function () { a.solve(rhs); })
     .add('a.trace()', function () { a.trace(); })
     .add('a.swap(i, j)', function () { a.swap(Math.floor(Math.random() * N), Math.floor(Math.random() * N)); })
     .on('cycle', function (event) { console.log(String(event.target)); })

--- a/matrix.js
+++ b/matrix.js
@@ -475,7 +475,7 @@
    * @param {Int32Array} array of pivoted row indices
    * @returns {Matrix} rhs replaced by the solution
    **/
-  Matrix.prototype.lu_solve = function (rhs, ipiv) {
+  Matrix.prototype.lusolve = function (rhs, ipiv) {
     var lu = this.data,
         n = rhs.shape[0],
         nrhs = rhs.shape[1],
@@ -516,7 +516,7 @@
         lu = plu[0],
         ipiv = plu[1];
 
-    return lu.lu_solve(new Matrix(rhs), ipiv);
+    return lu.lusolve(new Matrix(rhs), ipiv);
   };
 
   /**

--- a/matrix.js
+++ b/matrix.js
@@ -388,41 +388,6 @@
   };
 
   /**
-   * Pivots a matrix until elements are in upper triangular form
-   * @returns {Array} a tuple of the resultant pivotized matrix and its sign
-   * (used in LU factorization).
-   **/
-  Matrix.prototype.pivotize = function () {
-    var l = this.shape[0],
-        result = Matrix.identity(l),
-        sign = 1,
-        pivot,
-        lead,
-        row;
-
-    var i, j;
-    for (i = 0; i < l; i++) {
-      pivot = 0;
-      row = i;
-
-      for (j = i; j < l; j++) {
-        lead = Math.abs(this.get(j, i));
-        if (pivot < lead) {
-          pivot = lead;
-          row = j;
-        }
-      }
-
-      if (i !== row) {
-        result.swap(i, row);
-        sign *= -1;
-      }
-    }
-
-    return [result, sign];
-  };
-
-  /**
    * Performs full LU decomposition on a matrix.
    * @returns {Array} a triple (3-tuple) of the lower triangular resultant matrix `L`, the upper
    * triangular resultant matrix `U` and the pivot array `ipiv`
@@ -502,6 +467,56 @@
     }
 
     return [this, ipiv];
+  };
+
+  /**
+   * Solves an LU factorized matrix with the supplied right hand side(s)
+   * @param {Matrix} rhs, right hand side(s) to solve for
+   * @param {Int32Array} array of pivoted row indices
+   * @returns {Matrix} rhs replaced by the solution
+   **/
+  Matrix.prototype.lu_solve = function (rhs, ipiv) {
+    var lu = this.data,
+        n = rhs.shape[0],
+        nrhs = rhs.shape[1],
+        x = rhs.data,
+        i, j, k;
+
+    // pivot right hand side
+    for (i = 0; i < ipiv.length; i++)
+      if (i !== ipiv[i])
+        rhs.swap(i, ipiv[i]);
+
+    for (k = 0; k < nrhs; k++) {
+      // forward solve
+      for (i = 0; i < n; i++)
+        for (j = 0; j < i; j++)
+          x[i * nrhs + k] -= lu[i * n + j] * x[j * nrhs + k];
+
+      // backward solve
+      for (i = n - 1; i >= 0; i--) {
+        for (j = i + 1; j < n; j++)
+          x[i * nrhs + k] -= lu[i * n + j] * x[j * nrhs + k];
+        x[i * nrhs + k] /= lu[i * n + i];
+      }
+    }
+
+    return rhs;
+  };
+
+  /**
+   * Solves AX = B using LU factorization, where A is the current matrix and
+   * B is a Vector/Matrix containing the right hand side(s) of the equation.
+   * @param {Matrix/Vector} rhs, right hand side(s) to solve for
+   * @param {Int32Array} array of pivoted row indices
+   * @returns {Matrix} a new matrix containing the solutions of the system
+   **/
+  Matrix.prototype.solve = function (rhs) {
+    var plu = Matrix.plu(this),
+        lu = plu[0],
+        ipiv = plu[1];
+
+    return lu.lu_solve(new Matrix(rhs), ipiv);
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "mocha": "^2.3.4",
-    "nblas": "^1.1.2"
+    "nblas": "^1.1.2",
+    "nlapack": "github:mateogianolio/nlapack"
   }
 }

--- a/test/matrix.js
+++ b/test/matrix.js
@@ -259,20 +259,6 @@
         });
       });
 
-      describe('.pivotize()', function() {
-        it('should work as expected', function() {
-          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
-          var b = new Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 1]]);
-
-          assert.deepEqual(b, a.pivotize().shift());
-
-          var c = new Matrix([[11, 9, 24, 2], [1, 5, 2, 6], [3, 17, 18, 1], [2, 5, 7, 1]]);
-          var d = new Matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]);
-
-          assert.deepEqual(d, c.pivotize().shift());
-        });
-      });
-
       describe('.lu()', function() {
         it('should work as expected', function() {
           var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
@@ -298,6 +284,18 @@
       });
 
       describe('.plu()', function() {
+        it('should work as expected', function() {
+          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
+          var b = new Matrix([[2, 4, 7], [0.5, 1, 1.5], [0.5, -1, -2]]);
+          var ipiv = new Int32Array([1, 1, 2]);
+
+          var plu = a.plu();
+          assert.deepEqual(ipiv, plu.pop());
+          assert.deepEqual(b, plu.pop());
+        });
+      });
+
+      describe('.lu_solve()', function() {
         it('should work as expected', function() {
           var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
           var b = new Matrix([[2, 4, 7], [0.5, 1, 1.5], [0.5, -1, -2]]);

--- a/test/matrix.js
+++ b/test/matrix.js
@@ -295,15 +295,28 @@
         });
       });
 
-      describe('.lu_solve()', function() {
+      describe('.lusolve()', function() {
         it('should work as expected', function() {
           var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
-          var b = new Matrix([[2, 4, 7], [0.5, 1, 1.5], [0.5, -1, -2]]);
-          var ipiv = new Int32Array([1, 1, 2]);
+          var rhs = new Matrix([[1], [3], [5]]);
+          var x = new Matrix([[3.25], [1.75], [-1.5]]);
 
-          var plu = a.plu();
-          assert.deepEqual(ipiv, plu.pop());
-          assert.deepEqual(b, plu.pop());
+          var plu = a.plu(),
+              lu = plu[0],
+              ipiv = plu[1];
+
+          lu.lusolve(rhs, ipiv);
+          assert.deepEqual(x, rhs);
+        });
+      });
+
+      describe('.solve()', function() {
+        it('should work as expected', function() {
+          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
+          var rhs = new Matrix([[1], [3], [5]]);
+          var x = new Matrix([[3.25], [1.75], [-1.5]]);
+
+          assert.deepEqual(x, a.solve(rhs));
         });
       });
 

--- a/test/matrix_optimized.js
+++ b/test/matrix_optimized.js
@@ -105,6 +105,67 @@
           assert.deepEqual(i, g.multiply(h));
         });
       });
+
+      describe('.lu()', function() {
+        it('should work as expected', function() {
+          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
+          var b = [
+            new Matrix([[1, 0, 0], [0.5, 1, 0], [0.5, -1, 1]]),
+            new Matrix([[2, 4, 7], [0, 1, 1.5], [0, 0, -2]])
+          ];
+
+          assert.deepEqual(b, a.lu().splice(0, 2));
+
+          var c = new Matrix([[11, 9, 24, 2], [1, 5, 2, 6], [3, 17, 18, 1], [2, 5, 7, 1]]);
+          var d = [
+            new Matrix([[1, 0, 0, 0], [0.27273, 1, 0, 0], [0.09091, 0.2875, 1, 0], [0.18182, 0.23125, 0.0036, 1]]),
+            new Matrix([[11, 9, 24, 2], [0, 14.54545, 11.45455, 0.45455], [0, 0, -3.475, 5.6875], [0, 0, 0, 0.51079]]),
+          ];
+
+          assert.deepEqual(d, c.lu().splice(0, 2).map(function(matrix) {
+            return matrix.map(function(value) {
+              return Number(value.toFixed(5));
+            });
+          }));
+        });
+      });
+
+      describe('.plu()', function() {
+        it('should work as expected', function() {
+          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
+          var b = new Matrix([[2, 4, 7], [0.5, 1, 1.5], [0.5, -1, -2]]);
+          var ipiv = new Int32Array([1, 1, 2]);
+
+          var plu = a.plu();
+          assert.deepEqual(ipiv, plu.pop());
+          assert.deepEqual(b, plu.pop());
+        });
+      });
+
+      describe('.lusolve()', function() {
+        it('should work as expected', function() {
+          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
+          var rhs = new Matrix([[1], [3], [5]]);
+          var x = new Matrix([[3.25], [1.75], [-1.5]]);
+
+          var plu = a.plu(),
+              lu = plu[0],
+              ipiv = plu[1];
+
+          lu.lusolve(rhs, ipiv);
+          assert.deepEqual(x, rhs);
+        });
+      });
+
+      describe('.solve()', function() {
+        it('should work as expected', function() {
+          var a = new Matrix([[1, 3, 5], [2, 4, 7], [1, 1, 0]]);
+          var rhs = new Matrix([[1], [3], [5]]);
+          var x = new Matrix([[3.25], [1.75], [-1.5]]);
+
+          assert.deepEqual(x, a.solve(rhs));
+        });
+      });
     });
   });
 })();

--- a/vectorious.js
+++ b/vectorious.js
@@ -4,7 +4,8 @@
   var Vector = require('./vector'),
       Matrix = require('./matrix');
   try {
-    var nblas = require('nblas');
+    var nblas = require('nblas'),
+        nlapack = require('nlapack');
   } catch (error) {
     module.exports.Vector = Vector;
     module.exports.Matrix = Matrix;
@@ -58,11 +59,11 @@
     return nblas.nrm2(this.data);
   };
 
-  Vector.prototype.max = function() {
+  Vector.prototype.max = function () {
     return this.data[nblas.idamax(this.length, this.data, 1)];
   };
 
-  Matrix.prototype.multiply = function(matrix) {
+  Matrix.prototype.multiply = function (matrix) {
     var r1 = this.shape[0],
         c1 = this.shape[1],
         r2 = matrix.shape[0],
@@ -74,6 +75,24 @@
 
     nblas.gemm(this.data, matrix.data, data, r1, c2, c1);
     return Matrix.fromTypedArray(data, [r1, c2]);
+  };
+
+  // LAPACK optimizations
+  Matrix.prototype.plu = function () {
+    var r = this.shape[0],
+        c = this.shape[1],
+        ipiv = new Int32Array(r);
+
+    nlapack.getrf(r, c, this.data, ipiv);
+    return [this, ipiv];
+  };
+
+  Matrix.prototype.lu_solve = function (rhs, ipiv) {
+    var r = this.shape[0],
+        nrhs = rhs.shape[1];
+
+    nlapack.getrs(r, this.data, rhs.data, ipiv, nrhs);
+    return rhs;
   };
 
   module.exports.Vector = Vector;

--- a/vectorious.js
+++ b/vectorious.js
@@ -87,7 +87,7 @@
     return [this, ipiv];
   };
 
-  Matrix.prototype.lu_solve = function (rhs, ipiv) {
+  Matrix.prototype.lusolve = function (rhs, ipiv) {
     var r = this.shape[0],
         nrhs = rhs.shape[1];
 


### PR DESCRIPTION
Removes `Matrix.prototype.pivotize`.

**Additions**

```javascript
/**
 * Solves an LU factorized matrix with the supplied right hand side(s)
 * @param {Matrix} rhs, right hand side(s) to solve for
 * @param {Int32Array} array of pivoted row indices
 * @returns {Matrix} rhs replaced by the solution
 **/
Matrix.prototype.lusolve = function (rhs, ipiv)
```

```javascript
/**
 * Solves AX = B using LU factorization, where A is the current matrix and
 * B is a Vector/Matrix containing the right hand side(s) of the equation.
 * @param {Matrix/Vector} rhs, right hand side(s) to solve for
 * @param {Int32Array} array of pivoted row indices
 * @returns {Matrix} a new matrix containing the solutions of the system
 **/
Matrix.prototype.solve = function (rhs)
```

Adds LAPACK bindings to `Matrix.prototype.plu` and `Matrix.prototype.lusolve`.

Not final, will add more to this PR in the future.