### PR TITLE
Matrix transpose fix

### DIFF
--- a/examples/neural-network.js
+++ b/examples/neural-network.js
@@ -9,9 +9,6 @@
   var add = Matrix.add,
       subtract = Matrix.subtract,
       dot = Matrix.multiply,
-      scale = Matrix.scale,
-      ones = Matrix.ones,
-      zeros = Matrix.zeros,
       random = Matrix.random;
 
   // element-wise matrix multiplication
@@ -32,11 +29,13 @@
 
   // inputs and outputs
   var X = new Matrix([[0, 0, 1], [0, 1, 1], [1, 0, 1], [1, 1, 1]]),
-      y = new Matrix([[0, 1, 1, 0]]).transpose();
+      y = new Matrix([[0, 1, 1, 0]]).T;
 
-  // weights
-  var syn0 = random(3, 4),
-      syn1 = random(4, 1);
+  console.log(X.shape, y.shape);
+
+  // initialize weights with a standard deviation of 2 and mean -1
+  var syn0 = random.apply(null, X.T.shape, 2, -1),
+      syn1 = random.apply(null, y.shape, 2, -1);
 
   // layers and deltas
   var l0,
@@ -49,10 +48,10 @@
     l1 = dot(l0, syn1).map(sigmoid());
 
     l1_delta = mul(subtract(y, l1), l1.map(sigmoid(true)));
-    l0_delta = mul(dot(l1_delta, syn1.transpose()), l0.map(sigmoid(true)));
+    l0_delta = mul(dot(l1_delta, syn1.T), l0.map(sigmoid(true)));
 
-    syn1 = add(syn1, dot(l0.transpose(), l1_delta));
-    syn0 = add(syn0, dot(X.transpose(), l0_delta));
+    syn1 = add(syn1, dot(l0.T, l1_delta));
+    syn0 = add(syn0, dot(X.T, l0_delta));
   }
 
   // final trained neural network output!

--- a/matrix.js
+++ b/matrix.js
@@ -187,21 +187,30 @@
   };
 
   /**
-   * Static method. Creates an `i x j` matrix containing random values between
-   * `0` and `1`, takes an optional `type` argument which should be an instance
-   * of `TypedArray`.
+   * Static method. Creates an `i x j` matrix containing random values
+   * according to a normal distribution, takes an optional `type` argument
+   * which should be an instance of `TypedArray`.
    * @param {Number} i
    * @param {Number} j
+   * @param {Number} mean (default 0)
+   * @param {Number} standard deviation (default 1)
    * @param {TypedArray} type
    * @returns {Matrix} a matrix of the specified dimensions and `type`
    **/
-  Matrix.random = function (i, j, type) {
+  Matrix.random = function (i, j, deviation, mean, type) {
+    if (deviation instanceof Function) {
+      type = deviation;
+      deviation = 1;
+    }
+
+    deviation = deviation || 1;
+    mean = mean || 0;
     type = type || Float64Array;
     var data = new type(i * j),
         k;
 
     for (k = 0; k < i * j; k++)
-      data[k] = Math.random();
+      data[k] = deviation * Math.random() + mean;
 
     return Matrix.fromTypedArray(data, [i, j]);
   };
@@ -250,34 +259,18 @@
   };
 
   /**
-   * Static method. Transposes a matrix (mirror across the diagonal).
-   * @returns {Matrix} a new resultant transposed matrix
-   **/
-  Matrix.transpose = function (matrix) {
-    return new Matrix(matrix).transpose();
-  };
-
-  /**
    * Transposes a matrix (mirror across the diagonal).
    * @returns {Matrix} `this`
    **/
+
+  Object.defineProperty(Matrix.prototype, 'T', {
+    get: function() { return this.transpose(); }
+  });
+
   Matrix.prototype.transpose = function () {
     var r = this.shape[0],
         c = this.shape[1],
         i, j;
-
-    // prefer in-place
-    if (r === c) {
-      for (i = 0; i < r - 1; i++) {
-        for (j = i + 1; j < r; j++) {
-          var tmp = this.data[j * r + i];
-          this.data[j * r + i] = this.data[i * r + j];
-          this.data[i * r + j] = tmp;
-        }
-      }
-
-      return this;
-    }
 
     var data = new this.type(c * r);
     for (i = 0; i < r; i++)

--- a/matrix.js
+++ b/matrix.js
@@ -198,11 +198,6 @@
    * @returns {Matrix} a matrix of the specified dimensions and `type`
    **/
   Matrix.random = function (i, j, deviation, mean, type) {
-    if (deviation instanceof Function) {
-      type = deviation;
-      deviation = 1;
-    }
-
     deviation = deviation || 1;
     mean = mean || 0;
     type = type || Float64Array;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectorious",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A high performance linear algebra library.",
   "main": "vectorious.js",
   "scripts": {

--- a/test/matrix.js
+++ b/test/matrix.js
@@ -198,14 +198,13 @@
 
         it('should work as expected', function() {
 
-          assert.deepEqual(a, Matrix.transpose(c));
-          assert.deepEqual(c, Matrix.transpose(a));
+          assert.deepEqual(a, c.T);
+          assert.deepEqual(c, a.T);
 
-          assert.deepEqual(b, Matrix.transpose(d));
-          assert.deepEqual(d, Matrix.transpose(b));
+          assert.deepEqual(b, d.T);
+          assert.deepEqual(d, b.T);
 
-          assert.deepEqual(e, Matrix.transpose(Matrix.transpose(e)));
-
+          assert.deepEqual(e, e.T.T);
         });
       });
 

--- a/vector.js
+++ b/vector.js
@@ -248,19 +248,23 @@
 
   /**
    * Static method. Creates a vector of `count` elements containing random
-   * values between `0` and `1`, takes an optional `type` argument which
-   * should be an instance of `TypedArray`.
+   * values according to a normal distribution, takes an optional `type`
+   * argument which should be an instance of `TypedArray`.
    * @param {Number} count
+   * @param {Number} deviation (default 1)
+   * @param {Number} mean (default 0)
    * @param {TypedArray} type
    * @returns {Vector} a new vector of the specified size and `type`
    **/
-  Vector.random = function (count, type) {
+  Vector.random = function (count, deviation, mean, type) {
+    deviation = deviation || 1;
+    mean = mean || 0;
     type = type || Float64Array;
     var data = new type(count),
         i;
 
     for (i = 0; i < count; i++)
-      data[i] = Math.random();
+      data[i] = deviation * Math.random() + mean;
 
     return new Vector(data);
   };


### PR DESCRIPTION
Fixes `Matrix.prototype.transpose()`, removing the in-place transposition if square matrix which was confusing. 

Introduces the simpler `matrix.T` alias to get Matrix transpose. It is also chainable, so:

```javascript
var matrix = new Matrix([[1, 2], [3, 4]]);
console.log(matrix.T.T.equal(matrix));
// true
```

Adds optional `deviation` (default 1) and `mean` (default 0) normal distribution parameters to `Matrix.random` and `Vector.random`, fixing #56:

```javascript
Matrix.random = function (i, j, deviation, mean, type)
Vector.random = function (count, deviation, mean, type)
```