### PR TITLE
add gradient descent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,14 @@ At the moment, Google Chrome seems to offer the best TypedArray support.
 
 ### Examples
 
-* [Solving **linear systems of equations**](https://github.com/mateogianolio/vectorious/tree/master/examples/solve.js)
-* [Implementing a **neural network**](https://github.com/mateogianolio/vectorious/tree/master/examples/neural-network.js) (by [@lucidrains](https://github.com/lucidrains))
-* [Using low-level **BLAS routines**](https://github.com/mateogianolio/vectorious/tree/master/examples/blas.js)
+**Basic**
+
+* [**Solving linear systems of equations**](https://github.com/mateogianolio/vectorious/tree/master/examples/solve.js)
+* [**Using low-level BLAS routines**](https://github.com/mateogianolio/vectorious/tree/master/examples/blas.js)
+
+**Machine learning**
+* [**Backpropagation**](https://github.com/mateogianolio/vectorious/tree/master/examples/neural-network.js) (by [@lucidrains](https://github.com/lucidrains))
+* [**Gradient descent**](https://github.com/mateogianolio/vectorious/tree/master/examples/neural-network.js)
 
 ### Documentation
 

--- a/examples/backpropagation.js
+++ b/examples/backpropagation.js
@@ -8,7 +8,6 @@
   // aliases
   var add = Matrix.add,
       subtract = Matrix.subtract,
-      dot = Matrix.multiply,
       random = Matrix.random;
 
   // element-wise matrix multiplication
@@ -31,8 +30,6 @@
   var X = new Matrix([[0, 0, 1], [0, 1, 1], [1, 0, 1], [1, 1, 1]]),
       y = new Matrix([[0, 1, 1, 0]]).T;
 
-  console.log(X.shape, y.shape);
-
   // initialize weights with a standard deviation of 2 and mean -1
   var syn0 = random.apply(null, X.T.shape, 2, -1),
       syn1 = random.apply(null, y.shape, 2, -1);
@@ -44,14 +41,14 @@
       l1_delta;
 
   for (var i = 0; i < 60000; i++) {
-    l0 = dot(X, syn0).map(sigmoid());
-    l1 = dot(l0, syn1).map(sigmoid());
+    l0 = X.multiply(syn0).map(sigmoid());
+    l1 = l0.multiply(syn1).map(sigmoid());
 
     l1_delta = mul(subtract(y, l1), l1.map(sigmoid(true)));
-    l0_delta = mul(dot(l1_delta, syn1.T), l0.map(sigmoid(true)));
+    l0_delta = mul(l1_delta.multiply(syn1.T), l0.map(sigmoid(true)));
 
-    syn1 = add(syn1, dot(l0.T, l1_delta));
-    syn0 = add(syn0, dot(X.T, l0_delta));
+    syn1 = add(syn1, l0.T.multiply(l1_delta));
+    syn0 = add(syn0, X.T.multiply(l0_delta));
   }
 
   // final trained neural network output!

--- a/examples/gradient-descent.js
+++ b/examples/gradient-descent.js
@@ -6,8 +6,7 @@
   var Matrix = require('../vectorious').Matrix;
 
   // aliases
-  var add = Matrix.add,
-      subtract = Matrix.subtract,
+  var subtract = Matrix.subtract,
       random = Matrix.random;
 
   // element-wise matrix multiplication

--- a/examples/gradient-descent.js
+++ b/examples/gradient-descent.js
@@ -1,0 +1,60 @@
+(function () {
+  // example is based on the numpy neural network tutorial featured here
+  // https://iamtrask.github.io//2015/07/27/python-network-part2/
+  'use strict';
+
+  var Matrix = require('../vectorious').Matrix;
+
+  // aliases
+  var add = Matrix.add,
+      subtract = Matrix.subtract,
+      random = Matrix.random;
+
+  // element-wise matrix multiplication
+  function mul(a, b) {
+    return a.map(function (val, i, j) {
+      return val * b.get(i, j);
+    });
+  }
+
+  // sigmoid function (and derivative)
+  function sigmoid(ddx) {
+    return function (x) {
+      return ddx ?
+        x * (1 - x) :
+        1.0 / (1 + Math.exp(-x));
+    };
+  }
+
+  // inputs and outputs
+  var X = new Matrix([[0, 0, 1], [0, 1, 1], [1, 0, 1], [1, 1, 1]]),
+      y = new Matrix([[0, 1, 1, 0]]).T;
+
+  var alpha = 0.5,
+      hidden_dim = 4;
+
+  // initialize weights with a standard deviation of 2 and mean -1
+  var syn0 = random(X.T.shape[0], hidden_dim, 2, -1),
+      syn1 = random(hidden_dim, 1, 2, -1);
+
+  // layers and deltas
+  var l0,
+      l1,
+      l0_delta,
+      l1_delta;
+
+  for (var i = 0; i < 60000; i++) {
+    l0 = X.multiply(syn0).map(sigmoid());
+    l1 = l0.multiply(syn1).map(sigmoid());
+
+    l1_delta = mul(subtract(l1, y), l1.map(sigmoid(true)));
+    l0_delta = mul(l1_delta.multiply(syn1.T), l0.map(sigmoid(true)));
+
+    syn1 = subtract(syn1, l0.T.multiply(l1_delta).scale(alpha));
+    syn0 = subtract(syn0, X.T.multiply(l0_delta).scale(alpha));
+  }
+
+  // final trained neural network output!
+  // should be closed to [[0, 1, 1, 0]] transpose
+  console.log(l1.toArray());
+}());


### PR DESCRIPTION
Following @lucidrains neural network example, I took the liberty of adding a javascript version of gradient descent from part 2 in the series: [A Neural Network in 13 lines of Python (Part 2 - Gradient Descent)](https://iamtrask.github.io//2015/07/27/python-network-part2/)