### PR TITLE
Fix #76 - add Vector#x, #y, #z, #w properties

### DIFF
--- a/test/vector.js
+++ b/test/vector.js
@@ -262,6 +262,32 @@
         });
       });
 
+      describe('.x, .y, .z, .w', function() {
+        it('should retrieve properties as expected', function() {
+          var a = new Vector([1,2,3,4,5]);
+
+          assert.equal(a.x, 1)
+          assert.equal(a.y, 2)
+          assert.equal(a.z, 3)
+          assert.equal(a.w, 4)
+        });
+
+        it('should set proeprties as expected', function() {
+          var a = new Vector([-1,-1,-1,-1]);
+
+          a.x = 0;
+          a.y = 1;
+          a.z = 2;
+          a.w = 3;
+
+          assert.equal(a.get(0), 0);
+          assert.equal(a.get(1), 1);
+          assert.equal(a.get(2), 2);
+          assert.equal(a.get(3), 3);
+
+        })
+      })
+
       describe('.min()', function() {
         it('should find the minimum number in vectors', function() {
           var a = new Vector([1, 2, 3]);

--- a/vector.js
+++ b/vector.js
@@ -429,6 +429,44 @@
   };
 
   /**
+   * Convenience property for vector[0]
+   * @property {Number}
+   * @name Vector#x
+   */
+
+  /**
+   * Convenience property for vector[1]
+   * @property {Number}
+   * @name Vector#y
+   */
+
+  /**
+   * Convenience property for vector[2]
+   * @property {Number}
+   * @name Vector#z
+   */
+
+  /**
+   * Convenience property for vector[3]
+   * @property {Number}
+   * @name Vector#w
+   */
+
+  function indexProperty(index) {
+    return {
+      get: function() { return this.get(index); },
+      set: function(value) { return this.set(index, value) }
+    };
+  }
+
+  Object.defineProperties(Vector.prototype, {
+    x: indexProperty(0),
+    y: indexProperty(1),
+    z: indexProperty(2),
+    w: indexProperty(3)
+  });
+
+  /**
    * Static method. Combines two vectors `a` and `b` (appends `b` to `a`).
    * @param {Vector} a
    * @param {Vector} b


### PR DESCRIPTION
This adds properties to `Vector.prototype` so that `.x`, `.y`, `.z`, and `.w` can be used to get and set indices 0, 1, 2, and 3 of a Vector, respectively. Fixes #76.