### PR TITLE
Make nblas a peer dependency

### DIFF
--- a/applyBlasOptimizations.js
+++ b/applyBlasOptimizations.js
@@ -1,0 +1,68 @@
+module.exports = function(Vector, Matrix, nblas) {
+  'use strict';
+  
+  // BLAS optimizations
+  Vector.prototype.add =
+  Matrix.prototype.add = function (data) {
+    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
+        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
+    if (l1 !== l2)
+      throw new Error('sizes do not match!');
+    if (!l1 && !l2)
+      return this;
+
+    nblas.axpy(data.data, this.data);
+    return this;
+  };
+
+  Vector.prototype.subtract =
+  Matrix.prototype.subtract = function (data) {
+    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
+        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
+    if (l1 !== l2)
+      throw new Error('sizes do not match!');
+    if (!l1 && !l2)
+      return this;
+
+    nblas.axpy(data.data, this.data, -1);
+    return this;
+  };
+
+  Vector.prototype.scale =
+  Matrix.prototype.scale = function (scalar) {
+    nblas.scal(this.data, scalar);
+    return this;
+  };
+
+  Vector.prototype.dot = function (vector) {
+    if (this.length !== vector.length)
+      throw new Error('sizes do not match!');
+
+    return nblas.dot(this.data, vector.data);
+  };
+
+  Vector.prototype.magnitude = function () {
+    if (!this.length)
+      return 0;
+
+    return nblas.nrm2(this.data);
+  };
+
+  Vector.prototype.max = function() {
+    return this.data[nblas.idamax(this.length, this.data, 1)];
+  };
+
+  Matrix.prototype.multiply = function(matrix) {
+    var r1 = this.shape[0],
+        c1 = this.shape[1],
+        r2 = matrix.shape[0],
+        c2 = matrix.shape[1],
+        data = new this.type(r1 * c2);
+
+    if (c1 !== r2)
+      throw new Error('sizes do not match');
+
+    nblas.gemm(this.data, matrix.data, data, r1, c2, c1);
+    return Matrix.fromTypedArray(data, [r1, c2]);
+  };
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A high performance linear algebra library.",
   "main": "vectorious.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha",
+    "test": "mocha",
     "benchmark": "node ./benchmarks/vector.js && node ./benchmarks/matrix.js",
     "coverage": "istanbul cover _mocha -- -R spec"
   },
@@ -19,6 +19,9 @@
     "algebra"
   ],
   "author": "Mateo Gianolio",
+  "contributors": [
+    "Bart van Andel <bavanandel@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mateogianolio/vectorious/issues"
@@ -28,7 +31,7 @@
     "benchmark": "^2.1.0",
     "mocha": "^2.4.5"
   },
-  "dependencies": {
+  "peerDependencies": {
     "nblas": "^1.2.0"
   }
 }

--- a/vectorious.js
+++ b/vectorious.js
@@ -1,82 +1,15 @@
 (function () {
   'use strict';
 
-  var Vector = require('./vector'),
-      Matrix = require('./matrix');
+  var Vector = module.exports.Vector = require('./vector'),
+      Matrix = module.exports.Matrix = require('./matrix');
+
   try {
-    var nblas = require('nblas');
+    var nblas = module.exports.BLAS = require('nblas'),
+        applyBlasOptimizations = require('./applyBlasOptimizations');
+    
+    applyBlasOptimizations(Vector, Matrix, nblas);
   } catch (error) {
-    module.exports.Vector = Vector;
-    module.exports.Matrix = Matrix;
-    return;
+
   }
-
-  // BLAS optimizations
-  Vector.prototype.add =
-  Matrix.prototype.add = function (data) {
-    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
-        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
-    if (l1 !== l2)
-      throw new Error('sizes do not match!');
-    if (!l1 && !l2)
-      return this;
-
-    nblas.axpy(data.data, this.data);
-    return this;
-  };
-
-  Vector.prototype.subtract =
-  Matrix.prototype.subtract = function (data) {
-    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
-        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
-    if (l1 !== l2)
-      throw new Error('sizes do not match!');
-    if (!l1 && !l2)
-      return this;
-
-    nblas.axpy(data.data, this.data, -1);
-    return this;
-  };
-
-  Vector.prototype.scale =
-  Matrix.prototype.scale = function (scalar) {
-    nblas.scal(this.data, scalar);
-    return this;
-  };
-
-  Vector.prototype.dot = function (vector) {
-    if (this.length !== vector.length)
-      throw new Error('sizes do not match!');
-
-    return nblas.dot(this.data, vector.data);
-  };
-
-  Vector.prototype.magnitude = function () {
-    if (!this.length)
-      return 0;
-
-    return nblas.nrm2(this.data);
-  };
-
-  Vector.prototype.max = function() {
-    return this.data[nblas.idamax(this.length, this.data, 1)];
-  };
-
-  Matrix.prototype.multiply = function(matrix) {
-    var r1 = this.shape[0],
-        c1 = this.shape[1],
-        r2 = matrix.shape[0],
-        c2 = matrix.shape[1],
-        data = new this.type(r1 * c2);
-
-    if (c1 !== r2)
-      throw new Error('sizes do not match');
-
-    nblas.gemm(this.data, matrix.data, data, r1, c2, c1);
-    return Matrix.fromTypedArray(data, [r1, c2]);
-  };
-
-  module.exports.Vector = Vector;
-  module.exports.Matrix = Matrix;
-  module.exports.BLAS = nblas;
 }());

--- a/withblas.js
+++ b/withblas.js
@@ -1,0 +1,11 @@
+(function () {
+  'use strict';
+
+  var Vector = module.exports.Vector = require('./vector'),
+      Matrix = module.exports.Matrix = require('./matrix'),
+      nblas = module.exports.BLAS = require('nblas'),
+
+      applyBlasOptimizations = require('./applyBlasOptimizations');
+
+  applyBlasOptimizations(Vector, Matrix, nblas);
+}());

--- a/withoutblas.js
+++ b/withoutblas.js
@@ -1,0 +1,6 @@
+(function () {
+  'use strict';
+
+  var Vector = module.exports.Vector = require('./vector'),
+      Matrix = module.exports.Matrix = require('./matrix');
+}());


### PR DESCRIPTION
Although 'vectorious.js' in current master treats 'nblas' as though its presence is optional, trying to use the package as an npm dependency will fail if 'nblas' cannot be installed. I assume this is undesired behavior, because it can run perfectly fine without it, and this is in fact necessary when using the library in the browser (e.g. client-side only code).

This patch addresses this issue by making nblas a peer dependency explicitly. This means that users of vectorious will have to add nblas to their dependencies themselves. It would also be possible to make nblas an optional dependency (using 'optionalDependencies' instead of 'peerDependencies'), which would cause npm to try and install nblas but continue (not fail) when installing fails.

Furthermore, two explicit entry points 'withblas' and 'withoutblas' have been added so developers can select either when required. This would for example be desired when 'nblas' is (or can be) installed locally without issues, but the developer is building for the web, i.e. without node as a backend.

The default entry point is still 'vectorious.js' and behaves just like before. The part which relies on 'nblas' has been refactored into a separate file though so it can be used by the 'withblas' easily as well.