### PR TITLE
make nblas an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "benchmark": "^2.1.0",
     "mocha": "^2.4.5"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "nblas": "^1.2.0"
   }
 }


### PR DESCRIPTION
@mateogianolio and @bartvanandel

Perhaps simply making nblas an optional dependency makes the most sense after considering #96.

Compare <a href="https://github.com/mateogianolio/vectorious/blob/master/vectorious.js#L6-L12">this block</a> and <a href="https://docs.npmjs.com/files/package.json#optionaldependencies">the package.json docs</a>.

In this case, if nblas fails to install, the build will continue...