### PR TITLE
Call mocha the npm way, fixes running tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A high performance linear algebra library.",
   "main": "vectorious.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha",
+    "test": "mocha",
     "benchmark": "node ./benchmarks/vector.js && node ./benchmarks/matrix.js",
     "coverage": "istanbul cover _mocha -- -R spec"
   },


### PR DESCRIPTION
Npm is aware of binaries from dependencies, so you can simply call "mocha" from npm scripts such as test.