### PR TITLE
Supply explicit 'withblas' and 'withoutblas' entry points

### DIFF
--- a/applyBlasOptimizations.js
+++ b/applyBlasOptimizations.js
@@ -1,0 +1,68 @@
+module.exports = function(Vector, Matrix, nblas) {
+  'use strict';
+  
+  // BLAS optimizations
+  Vector.prototype.add =
+  Matrix.prototype.add = function (data) {
+    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
+        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
+    if (l1 !== l2)
+      throw new Error('sizes do not match!');
+    if (!l1 && !l2)
+      return this;
+
+    nblas.axpy(data.data, this.data);
+    return this;
+  };
+
+  Vector.prototype.subtract =
+  Matrix.prototype.subtract = function (data) {
+    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
+        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
+    if (l1 !== l2)
+      throw new Error('sizes do not match!');
+    if (!l1 && !l2)
+      return this;
+
+    nblas.axpy(data.data, this.data, -1);
+    return this;
+  };
+
+  Vector.prototype.scale =
+  Matrix.prototype.scale = function (scalar) {
+    nblas.scal(this.data, scalar);
+    return this;
+  };
+
+  Vector.prototype.dot = function (vector) {
+    if (this.length !== vector.length)
+      throw new Error('sizes do not match!');
+
+    return nblas.dot(this.data, vector.data);
+  };
+
+  Vector.prototype.magnitude = function () {
+    if (!this.length)
+      return 0;
+
+    return nblas.nrm2(this.data);
+  };
+
+  Vector.prototype.max = function() {
+    return this.data[nblas.idamax(this.length, this.data, 1)];
+  };
+
+  Matrix.prototype.multiply = function(matrix) {
+    var r1 = this.shape[0],
+        c1 = this.shape[1],
+        r2 = matrix.shape[0],
+        c2 = matrix.shape[1],
+        data = new this.type(r1 * c2);
+
+    if (c1 !== r2)
+      throw new Error('sizes do not match');
+
+    nblas.gemm(this.data, matrix.data, data, r1, c2, c1);
+    return Matrix.fromTypedArray(data, [r1, c2]);
+  };
+};

--- a/vectorious.js
+++ b/vectorious.js
@@ -1,82 +1,15 @@
 (function () {
   'use strict';
 
-  var Vector = require('./vector'),
-      Matrix = require('./matrix');
+  var Vector = module.exports.Vector = require('./vector'),
+      Matrix = module.exports.Matrix = require('./matrix');
+
   try {
-    var nblas = require('nblas');
+    var nblas = module.exports.BLAS = require('nblas'),
+        applyBlasOptimizations = require('./applyBlasOptimizations');
+    
+    applyBlasOptimizations(Vector, Matrix, nblas);
   } catch (error) {
-    module.exports.Vector = Vector;
-    module.exports.Matrix = Matrix;
-    return;
+
   }
-
-  // BLAS optimizations
-  Vector.prototype.add =
-  Matrix.prototype.add = function (data) {
-    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
-        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
-    if (l1 !== l2)
-      throw new Error('sizes do not match!');
-    if (!l1 && !l2)
-      return this;
-
-    nblas.axpy(data.data, this.data);
-    return this;
-  };
-
-  Vector.prototype.subtract =
-  Matrix.prototype.subtract = function (data) {
-    var l1 = this instanceof Vector ? this.length : this.shape[0] * this.shape[1],
-        l2 = data instanceof Vector ? data.length : data.shape[0] * data.shape[1];
-    if (l1 !== l2)
-      throw new Error('sizes do not match!');
-    if (!l1 && !l2)
-      return this;
-
-    nblas.axpy(data.data, this.data, -1);
-    return this;
-  };
-
-  Vector.prototype.scale =
-  Matrix.prototype.scale = function (scalar) {
-    nblas.scal(this.data, scalar);
-    return this;
-  };
-
-  Vector.prototype.dot = function (vector) {
-    if (this.length !== vector.length)
-      throw new Error('sizes do not match!');
-
-    return nblas.dot(this.data, vector.data);
-  };
-
-  Vector.prototype.magnitude = function () {
-    if (!this.length)
-      return 0;
-
-    return nblas.nrm2(this.data);
-  };
-
-  Vector.prototype.max = function() {
-    return this.data[nblas.idamax(this.length, this.data, 1)];
-  };
-
-  Matrix.prototype.multiply = function(matrix) {
-    var r1 = this.shape[0],
-        c1 = this.shape[1],
-        r2 = matrix.shape[0],
-        c2 = matrix.shape[1],
-        data = new this.type(r1 * c2);
-
-    if (c1 !== r2)
-      throw new Error('sizes do not match');
-
-    nblas.gemm(this.data, matrix.data, data, r1, c2, c1);
-    return Matrix.fromTypedArray(data, [r1, c2]);
-  };
-
-  module.exports.Vector = Vector;
-  module.exports.Matrix = Matrix;
-  module.exports.BLAS = nblas;
 }());

--- a/withblas.js
+++ b/withblas.js
@@ -1,0 +1,11 @@
+(function () {
+  'use strict';
+
+  var Vector = module.exports.Vector = require('./vector'),
+      Matrix = module.exports.Matrix = require('./matrix'),
+      nblas = module.exports.BLAS = require('nblas'),
+
+      applyBlasOptimizations = require('./applyBlasOptimizations');
+
+  applyBlasOptimizations(Vector, Matrix, nblas);
+}());

--- a/withoutblas.js
+++ b/withoutblas.js
@@ -1,0 +1,6 @@
+(function () {
+  'use strict';
+
+  var Vector = module.exports.Vector = require('./vector'),
+      Matrix = module.exports.Matrix = require('./matrix');
+}());


### PR DESCRIPTION
This PR adds two entry points for explicitly using the library with or without BLAS. ES6-style examples below.

Default usage (unchanged), which uses BLAS if it can load `nblas`:
`import vectorious from 'vectorious';`

Explicitly require BLAS optimizations:
`import vectorious from 'vectorious/withblas';`

Explicitly don't use BLAS:
`import vectorious from 'vectorious/withoutblas';`

(previously included in #96)