### PR TITLE
Add contributors to package

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+Bart van Andel <bavanandel@gmail.com> <bvanandel@cyclomedia.com>
+Daniel Wang <pvnr0082t@gmail.com>
+James Vickers <james@metabench.com>
+Jarrad Whitaker <akdor1154@gmail.com>
+Mateo Gianolio <gianoliomateo@gmail.com>
+Michael Schock <mschock@ocf.berkeley.edu>
+Phillip Wang <lucidrains@gmail.com>
+Waylon Flinn <waylonflinn@gmail.com>
+Xuefeng Zhu <xzhu15@illinois.edu>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
     "algebra"
   ],
   "author": "Mateo Gianolio",
+  "contributors": [
+    "Bart van Andel <bavanandel@gmail.com>",
+    "James Vickers",
+    "Phillip Wang",
+    "Waylon Flinn",
+    "Xuefeng Zhu"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mateogianolio/vectorious/issues"


### PR DESCRIPTION
This PR adds every contributor with at least 2 commits to the package.json file. While email addresses are basically available for all, some people may not want them visible, so I've only added my own.

Also added a `.mailmap` file to normalize committers' names and email addresses when doing `git shortlog -s -e`.